### PR TITLE
Fix the initial step in parallel lgssm inference.

### DIFF
--- a/dynamax/linear_gaussian_ssm/parallel_inference.py
+++ b/dynamax/linear_gaussian_ssm/parallel_inference.py
@@ -19,8 +19,8 @@ def make_associative_filtering_elements(params, emissions):
         S = H @ Q @ H.T + R
         CF, low = jsc.linalg.cho_factor(S)
 
-        m1 = F @ params.initial_mean
-        P1 = F @ params.initial_covariance @ F.T + Q
+        m1 = params.initial_mean
+        P1 = params.initial_covariance
         S1 = H @ P1 @ H.T + R
         K1 = jsc.linalg.solve(S1, H @ P1, assume_a='pos').T
 


### PR DESCRIPTION
Following the discussion in #233 this PR fixes the discrepancy between the serial and parallel inference algorithms by removing the initial 'predict step' in the parallel algorithm.

Additionally update and refactor the test to reflect the fact that we now expect these two algorithms to produce the identical  output (to within numerical error).