### PR TITLE
Implement functionality for arbitrary likelihood distributions and add Poisson.

### DIFF
--- a/dynamax/cond_moments_gaussian_filter/inference.py
+++ b/dynamax/cond_moments_gaussian_filter/inference.py
@@ -6,7 +6,6 @@ from dynamax.containers import GSSMPosterior
 from dynamax.distributions import MultiVariateNormal as MVN
 
 
-
 # Helper functions
 _get_params = lambda x, dim, t: x[t] if x.ndim == dim + 1 else x
 _process_fn = lambda f, u: (lambda x, y: f(x)) if u is None else f
@@ -72,7 +71,7 @@ def _condition_on(m, P, y_cond_mean, y_cond_cov, u, y, g_ev, g_cov, num_iter, li
         g_ev (Callable): Gaussian expectation value function.
         g_cov (Callable): Gaussian cross covariance function.
         num_iter (int): number of re-linearizations around posterior for update step.
-        likelihood_dist: a distribution object defined in dynamax.distributions for likelihood.
+        likelihood_dist: a distribution object defined in dynamax.distributions for likelihood computation.
 
      Returns:
         log_likelihood (Scalar): prediction log likelihood for observation y
@@ -136,7 +135,7 @@ def conditional_moments_gaussian_filter(params, emissions, num_iter=1, inputs=No
         emissions (T,D_hid): array of observations.
         num_iter (int): number of linearizations around prior/posterior for update step.
         inputs (T,D_in): array of inputs.
-        likelihood_dist: a distribution object defined in dynamax.distributions for likelihood.
+        likelihood_dist: a distribution object defined in dynamax.distributions for likelihood computation.
 
     Returns:
         filtered_posterior: GSSMPosterior instance containing,

--- a/dynamax/distributions.py
+++ b/dynamax/distributions.py
@@ -430,9 +430,14 @@ def nig_posterior_update(nig_prior, sufficient_stats):
 
 
 ###############################################################################
+# Inference Marginal Log-likelihood Distributions
 
 @chex.dataclass
 class InferenceDistribution:
+    """
+    Lightweight wrapper for likelihood distributions using which to
+    compute marginal loglikelihood during inference.
+    """
     mean: chex.Array = None
     cov: chex.Array = None
     
@@ -442,6 +447,10 @@ class InferenceDistribution:
 
 @chex.dataclass
 class MultiVariateNormal(InferenceDistribution):
+    """
+    Lightweight wrapper for MultiVariateNormalFullCovariance distribution
+    to use for inference.
+    """
     def log_prob(self, obs):
         mvn = tfd.MultivariateNormalFullCovariance(loc=self.mean, covariance_matrix=self.cov)
         return mvn.log_prob(obs)
@@ -449,6 +458,9 @@ class MultiVariateNormal(InferenceDistribution):
 
 @chex.dataclass
 class Poisson(InferenceDistribution):
+    """
+    Lightweight wrapper for Poisson distribution to use for inference.
+    """
     def log_prob(self, obs):
         pois = tfd.Poisson(rate=self.mean)
         return pois.log_prob(obs)

--- a/dynamax/extended_kalman_filter/inference.py
+++ b/dynamax/extended_kalman_filter/inference.py
@@ -1,7 +1,6 @@
 import jax.numpy as jnp
 from jax import lax
 from jax import jacfwd
-from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN
 from dynamax.containers import GSSMPosterior
 from dynamax.distributions import MultiVariateNormal as MVN
 


### PR DESCRIPTION
## Description
- All CMGF inference functions (i.e. (iterated)`conditional_moments_gaussian_filter`, (iterated)`conditional_moments_gaussian_smoother`) take in an additional argument `likelihood_dist` (default `=MultiVariateNormal`) which specifies which probability distribution to use to compute marginal log likelihood. 
- The likelihood distributions are to inherit the class `InferenceDistribution` in `dynamax/distributions.py`, which must be initialized with `mean` and `cov`, and must define `log_prob(.)` method.
- `MultiVariateNormal` and `Poisson` classes are implemented.
- Using `Poisson` distribution to compute marginal loglikelihood in the Poisson-CMGF demo led to noticeably-improved marginal log-likelihoods (see Figure below).


## Figures

<img width="976" alt="Screen Shot 2022-10-19 at 11 08 22 PM" src="https://user-images.githubusercontent.com/16075389/196855135-53104dd8-532a-4c8b-8d01-6bcc46b48102.png">


## Issue 
#237 