### PR TITLE
Update hmm parameters to use dataclasses instead of dicts.

### DIFF
--- a/dynamax/abstractions.py
+++ b/dynamax/abstractions.py
@@ -1,6 +1,5 @@
 from abc import ABC
 from abc import abstractmethod
-import blackjax
 from fastprogress.fastprogress import progress_bar
 from functools import partial
 import jax.numpy as jnp

--- a/dynamax/hmm/models/abstractions.py
+++ b/dynamax/hmm/models/abstractions.py
@@ -387,9 +387,9 @@ class HMM(SSM):
     def m_step(self, params, props, batch_stats, m_step_state):
         batch_initial_stats, batch_transition_stats, batch_emission_stats = batch_stats
         initial_m_step_state, transitions_m_step_state, emissions_m_step_state = m_step_state
-        params["initial"], initial_m_step_state = self.initial_component.m_step(params["initial"], props["initial"], batch_initial_stats, initial_m_step_state)
-        params["transitions"], transitions_m_step_state = self.transition_component.m_step(params["transitions"], props["transitions"], batch_transition_stats, transitions_m_step_state)
-        params["emissions"], emissions_m_step_state = self.emission_component.m_step(params["emissions"], props["emissions"], batch_emission_stats, emissions_m_step_state)
+        params.initial, initial_m_step_state = self.initial_component.m_step(params.initial, props["initial"], batch_initial_stats, initial_m_step_state)
+        params.transitions, transitions_m_step_state = self.transition_component.m_step(params.transitions, props["transitions"], batch_transition_stats, transitions_m_step_state)
+        params.emissions, emissions_m_step_state = self.emission_component.m_step(params.emissions, props["emissions"], batch_emission_stats, emissions_m_step_state)
         m_step_state = initial_m_step_state, transitions_m_step_state, emissions_m_step_state
         return params, m_step_state
 

--- a/dynamax/hmm/models/bernoulli_hmm.py
+++ b/dynamax/hmm/models/bernoulli_hmm.py
@@ -1,3 +1,4 @@
+import chex
 import jax.numpy as jnp
 import jax.random as jr
 import tensorflow_probability.substrates.jax.bijectors as tfb
@@ -77,6 +78,11 @@ class BernoulliHMMEmissions(HMMEmissions):
                 self.emission_prior_concentration0 + sum_1mx).mode()
         return params, m_step_state
 
+
+@chex.dataclass
+class HMMParams:
+    num_states: int
+    emission_dim: int
 
 class BernoulliHMM(HMM):
     def __init__(self, num_states: int,

--- a/dynamax/hmm/models/bernoulli_hmm.py
+++ b/dynamax/hmm/models/bernoulli_hmm.py
@@ -124,7 +124,7 @@ class BernoulliHMM(HMM):
             emission_probs (array, optional): manually specified emission probabilities. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:

--- a/dynamax/hmm/models/categorical_hmm.py
+++ b/dynamax/hmm/models/categorical_hmm.py
@@ -87,7 +87,7 @@ class CategoricalHMMEmissions(HMMEmissions):
     def m_step(self, params, props, batch_stats, m_step_state):
         if props['probs'].trainable:
             emission_stats = pytree_sum(batch_stats, axis=0)
-            params['probs'] = tfd.Dirichlet(
+            params.probs = tfd.Dirichlet(
                 self.emission_prior_concentration + emission_stats['sum_x']).mode()
         return params, m_step_state
 

--- a/dynamax/hmm/models/categorical_hmm.py
+++ b/dynamax/hmm/models/categorical_hmm.py
@@ -59,7 +59,7 @@ class CategoricalHMMEmissions(HMMEmissions):
             emission_probs (array, optional): manually specified emission probabilities. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         # Initialize the emission probabilities
@@ -137,7 +137,7 @@ class CategoricalHMM(HMM):
             emission_probs (array, optional): manually specified emission probabilities. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:

--- a/dynamax/hmm/models/gaussian_hmm.py
+++ b/dynamax/hmm/models/gaussian_hmm.py
@@ -280,7 +280,7 @@ class SphericalGaussianHMMEmissions(HMMEmissions):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if method.lower() == "kmeans":
@@ -381,7 +381,7 @@ class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if method.lower() == "kmeans":
@@ -501,7 +501,7 @@ class LowRankGaussianHMMEmissions(HMMEmissions):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if method.lower() == "kmeans":
@@ -606,7 +606,7 @@ class GaussianHMM(HMM):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:
@@ -676,7 +676,7 @@ class DiagonalGaussianHMM(HMM):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:
@@ -748,7 +748,7 @@ class SphericalGaussianHMM(HMM):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:
@@ -816,7 +816,7 @@ class SharedCovarianceGaussianHMM(HMM):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:
@@ -887,7 +887,7 @@ class LowRankGaussianHMM(HMM):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:

--- a/dynamax/hmm/models/gaussian_hmm.py
+++ b/dynamax/hmm/models/gaussian_hmm.py
@@ -3,6 +3,9 @@ import jax.random as jr
 import tensorflow_probability.substrates.jax.bijectors as tfb
 import tensorflow_probability.substrates.jax.distributions as tfd
 from jax import vmap
+import chex
+from jaxtyping import Float, Array
+import optax
 from dynamax.parameters import ParameterProperties
 from dynamax.distributions import InverseWishart
 from dynamax.distributions import NormalInverseGamma
@@ -10,10 +13,15 @@ from dynamax.distributions import NormalInverseWishart
 from dynamax.distributions import nig_posterior_update
 from dynamax.distributions import niw_posterior_update
 from dynamax.hmm.models.abstractions import HMM, HMMEmissions
-from dynamax.hmm.models.initial import StandardHMMInitialState
-from dynamax.hmm.models.transitions import StandardHMMTransitions
+from dynamax.hmm.models.initial import StandardHMMInitialState, ParamsStandardHMMInitialState
+from dynamax.hmm.models.transitions import StandardHMMTransitions, ParamsStandardHMMTransitions
 from dynamax.utils import PSDToRealBijector, pytree_sum
-import optax
+
+
+@chex.dataclass
+class ParamsGaussianHMMEmissions:
+    means: Float[Array, "state_dim emission_dim"]
+    covs: Float[Array, "state_dim emission_dim emission_dim"]
 
 
 class GaussianHMMEmissions(HMMEmissions):
@@ -78,8 +86,10 @@ class GaussianHMMEmissions(HMMEmissions):
 
         # Only use the values above if the user hasn't specified their own
         default = lambda x, x0: x if x is not None else x0
-        params = dict(means=default(emission_means, _emission_means),
-                      covs=default(emission_covariances, _emission_covs))
+        params = ParamsGaussianHMMEmissions(
+                    means=default(emission_means, _emission_means),
+                    covs=default(emission_covariances, _emission_covs)
+                    )
         props = dict(means=ParameterProperties(),
                      covs=ParameterProperties(constrainer=tfb.Invert(PSDToRealBijector)))
         return params, props
@@ -108,7 +118,7 @@ class GaussianHMMEmissions(HMMEmissions):
                 return niw_posterior.mode()
 
             emission_stats = pytree_sum(batch_stats, axis=0)
-            params['covs'], params['means'] = vmap(_single_m_step)(emission_stats)
+            params.covs, params.means = vmap(_single_m_step)(emission_stats)
 
         elif props['covs'].trainable and not props['means'].trainable:
             raise NotImplementedError("GaussianHMM.fit_em() does not yet support fixed means and trainable covariance")
@@ -117,6 +127,12 @@ class GaussianHMMEmissions(HMMEmissions):
             raise NotImplementedError("GaussianHMM.fit_em() does not yet support fixed covariance and trainable means")
 
         return params, m_step_state
+
+
+@chex.dataclass
+class ParamsDiagonalGaussianHMMEmissions:
+    means: Float[Array, "state_dim emission_dim"]
+    scale_diags: Float[Array, "state_dim emission_dim"]
 
 
 class DiagonalGaussianHMMEmissions(HMMEmissions):
@@ -166,8 +182,10 @@ class DiagonalGaussianHMMEmissions(HMMEmissions):
 
         # Only use the values above if the user hasn't specified their own
         default = lambda x, x0: x if x is not None else x0
-        params = dict(means=default(emission_means, _emission_means),
-                      scale_diags=default(emission_scale_diags, _emission_scale_diags))
+        params = ParamsDiagonalGaussianHMMEmissions(
+                    means=default(emission_means, _emission_means),
+                    scale_diags=default(emission_scale_diags, _emission_scale_diags)
+                    )
         props = dict(means=ParameterProperties(),
                      scale_diags=ParameterProperties(constrainer=tfb.Softplus()))
         return params, props
@@ -205,9 +223,15 @@ class DiagonalGaussianHMMEmissions(HMMEmissions):
 
         emission_stats = pytree_sum(batch_stats, axis=0)
         vars, means = vmap(_single_m_step)(emission_stats)
-        params['scale_diags'] = jnp.sqrt(vars)
-        params['means'] = means
+        params.scale_diags = jnp.sqrt(vars)
+        params.means = means
         return params, m_step_state
+
+
+@chex.dataclass
+class ParamsSphericalGaussianHMMEmissions:
+    means: Float[Array, "state_dim emission_dim"]
+    scales: Float[Array, "state_dim"] 
 
 
 class SphericalGaussianHMMEmissions(HMMEmissions):
@@ -281,8 +305,10 @@ class SphericalGaussianHMMEmissions(HMMEmissions):
 
         # Only use the values above if the user hasn't specified their own
         default = lambda x, x0: x if x is not None else x0
-        params = dict(means=default(emission_means, _emission_means),
-                      scales=default(emission_scales, _emission_scales))
+        params = ParamsSphericalGaussianHMMEmissions(
+                    means=default(emission_means, _emission_means),
+                    scales=default(emission_scales, _emission_scales)
+                    )
         props = dict(means=ParameterProperties(),
                      scales=ParameterProperties(constrainer=tfb.Softplus()))
         return params, props
@@ -299,6 +325,12 @@ class SphericalGaussianHMMEmissions(HMMEmissions):
         lp += tfd.Gamma(self.emission_var_concentration, self.emission_var_rate)\
             .log_prob(params['scales']**2).sum()
         return lp
+
+
+@chex.dataclass
+class ParamsSharedCovarianceGaussianHMMEmissions:
+    means: Float[Array, "state_dim emission_dim"]
+    cov: Float[Array, "emission_dim emission_dim"]
 
 
 class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
@@ -373,8 +405,10 @@ class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
 
         # Only use the values above if the user hasn't specified their own
         default = lambda x, x0: x if x is not None else x0
-        params = dict(means=default(emission_means, _emission_means),
-                      cov=default(emission_covariance, _emission_cov))
+        params = ParamsSharedCovarianceGaussianHMMEmissions(
+                    means=default(emission_means, _emission_means),
+                    cov=default(emission_covariance, _emission_cov)
+                    )
         props = dict(means=ParameterProperties(),
                      cov=ParameterProperties(constrainer=tfb.Invert(PSDToRealBijector)))
         return params, props
@@ -418,9 +452,16 @@ class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
         sum_w = emission_stats['sum_w'] + kappa0
         sum_x = emission_stats['sum_x'] + kappa0 * mu0
         sum_xxT = emission_stats['sum_xxT'] + Psi0 + kappa0 * jnp.outer(mu0, mu0)
-        params['means'] = jnp.einsum('ki,k->ki', sum_x, 1/sum_w)
-        params['cov'] = (sum_xxT - jnp.einsum('ki,kj,k->ij', sum_x, sum_x, 1/sum_w)) / sum_T
+        params.means = jnp.einsum('ki,k->ki', sum_x, 1/sum_w)
+        params.cov = (sum_xxT - jnp.einsum('ki,kj,k->ij', sum_x, sum_x, 1/sum_w)) / sum_T
         return params, m_step_state
+
+
+@chex.dataclass
+class ParamsLowRankGaussianHMMEmissions:
+    means: Float[Array, "state_dim emission_dim"]
+    cov_diag_factors: Float[Array, "state_dim emission_dim"]
+    cov_low_rank_factors: Float[Array, "state_dim emission_dim emission_rank"]
 
 
 class LowRankGaussianHMMEmissions(HMMEmissions):
@@ -485,9 +526,11 @@ class LowRankGaussianHMMEmissions(HMMEmissions):
 
         # Only use the values above if the user hasn't specified their own
         default = lambda x, x0: x if x is not None else x0
-        params = dict(means=default(emission_means, _emission_means),
-                      cov_diag_factors=default(emission_cov_diag_factors, _emission_cov_diag_factors),
-                      cov_low_rank_factors=default(emission_cov_low_rank_factors, _emission_cov_low_rank_factors))
+        params = ParamsLowRankGaussianHMMEmissions(
+                    means=default(emission_means, _emission_means),
+                    cov_diag_factors=default(emission_cov_diag_factors, _emission_cov_diag_factors),
+                    cov_low_rank_factors=default(emission_cov_low_rank_factors, _emission_cov_low_rank_factors)
+                    )
         props = dict(means=ParameterProperties(),
                      cov_diag_factors=ParameterProperties(constrainer=tfb.Softplus()),
                      cov_low_rank_factors=ParameterProperties())
@@ -510,7 +553,14 @@ class LowRankGaussianHMMEmissions(HMMEmissions):
         return lp
 
 
-# Now for the models
+### Now for the models ###
+@chex.dataclass
+class ParamsGaussianHMM:
+    initial: ParamsStandardHMMInitialState
+    transitions: ParamsStandardHMMTransitions
+    emissions: ParamsGaussianHMMEmissions
+
+
 class GaussianHMM(HMM):
     def __init__(self, num_states: int,
                  emission_dim: int,
@@ -568,7 +618,14 @@ class GaussianHMM(HMM):
         params["initial"], props["initial"] = self.initial_component.initialize(key1, method=method, initial_probs=initial_probs)
         params["transitions"], props["transitions"] = self.transition_component.initialize(key2, method=method, transition_matrix=transition_matrix)
         params["emissions"], props["emissions"] = self.emission_component.initialize(key3, method=method, emission_means=emission_means, emission_covariances=emission_covariances, emissions=emissions)
-        return params, props
+        return ParamsGaussianHMM(**params), props
+
+
+@chex.dataclass
+class ParamsDiagonalGaussianHMM:
+    initial: ParamsStandardHMMInitialState
+    transitions: ParamsStandardHMMTransitions
+    emissions: ParamsDiagonalGaussianHMMEmissions
 
 
 class DiagonalGaussianHMM(HMM):
@@ -631,7 +688,14 @@ class DiagonalGaussianHMM(HMM):
         params["initial"], props["initial"] = self.initial_component.initialize(key1, method=method, initial_probs=initial_probs)
         params["transitions"], props["transitions"] = self.transition_component.initialize(key2, method=method, transition_matrix=transition_matrix)
         params["emissions"], props["emissions"] = self.emission_component.initialize(key3, method=method, emission_means=emission_means, emission_scale_diags=emission_scale_diags, emissions=emissions)
-        return params, props
+        return ParamsDiagonalGaussianHMM(**params), props
+
+
+@chex.dataclass
+class ParamsSphericalGaussianHMM:
+    initial: ParamsStandardHMMInitialState
+    transitions: ParamsStandardHMMTransitions
+    emissions: ParamsSphericalGaussianHMMEmissions
 
 
 class SphericalGaussianHMM(HMM):
@@ -696,7 +760,14 @@ class SphericalGaussianHMM(HMM):
         params["initial"], props["initial"] = self.initial_component.initialize(key1, method=method, initial_probs=initial_probs)
         params["transitions"], props["transitions"] = self.transition_component.initialize(key2, method=method, transition_matrix=transition_matrix)
         params["emissions"], props["emissions"] = self.emission_component.initialize(key3, method=method, emission_means=emission_means, emission_scales=emission_scales, emissions=emissions)
-        return params, props
+        return ParamsSphericalGaussianHMM(**params), props
+
+
+@chex.dataclass
+class ParamsSharedCovarianceGaussianHMM:
+    initial: ParamsStandardHMMInitialState
+    transitions: ParamsStandardHMMTransitions
+    emissions: ParamsSharedCovarianceGaussianHMMEmissions
 
 
 class SharedCovarianceGaussianHMM(HMM):
@@ -757,7 +828,14 @@ class SharedCovarianceGaussianHMM(HMM):
         params["initial"], props["initial"] = self.initial_component.initialize(key1, method=method, initial_probs=initial_probs)
         params["transitions"], props["transitions"] = self.transition_component.initialize(key2, method=method, transition_matrix=transition_matrix)
         params["emissions"], props["emissions"] = self.emission_component.initialize(key3, method=method, emission_means=emission_means, emission_covariance=emission_covariance, emissions=emissions)
-        return params, props
+        return ParamsSharedCovarianceGaussianHMM(**params), props
+
+
+@chex.dataclass
+class ParamsLowRankGaussianHMM:
+    initial: ParamsStandardHMMInitialState
+    transitions: ParamsStandardHMMTransitions
+    emissions: ParamsLowRankGaussianHMMEmissions
 
 
 class LowRankGaussianHMM(HMM):
@@ -821,4 +899,4 @@ class LowRankGaussianHMM(HMM):
         params["initial"], props["initial"] = self.initial_component.initialize(key1, method=method, initial_probs=initial_probs)
         params["transitions"], props["transitions"] = self.transition_component.initialize(key2, method=method, transition_matrix=transition_matrix)
         params["emissions"], props["emissions"] = self.emission_component.initialize(key3, method=method, emission_means=emission_means, emission_cov_diag_factors=emission_cov_diag_factors, emission_cov_low_rank_factors=emission_cov_low_rank_factors, emissions=emissions)
-        return params, props
+        return ParamsLowRankGaussianHMM(**params), props

--- a/dynamax/hmm/models/gmm_hmm.py
+++ b/dynamax/hmm/models/gmm_hmm.py
@@ -4,15 +4,24 @@ import tensorflow_probability.substrates.jax.bijectors as tfb
 import tensorflow_probability.substrates.jax.distributions as tfd
 from jax import vmap
 from jax.scipy.special import logsumexp
+import chex
+from jaxtyping import Float, Array
 from dynamax.parameters import ParameterProperties
 from dynamax.distributions import NormalInverseGamma
 from dynamax.distributions import NormalInverseWishart
 from dynamax.distributions import nig_posterior_update
 from dynamax.distributions import niw_posterior_update
 from dynamax.hmm.models.abstractions import HMM, HMMEmissions
-from dynamax.hmm.models.initial import StandardHMMInitialState
-from dynamax.hmm.models.transitions import StandardHMMTransitions
+from dynamax.hmm.models.initial import StandardHMMInitialState, ParamsStandardHMMInitialState
+from dynamax.hmm.models.transitions import StandardHMMTransitions, ParamsStandardHMMTransitions
 from dynamax.utils import PSDToRealBijector, pytree_sum
+
+
+@chex.dataclass
+class ParamsGaussianMixtureHMMEmissions:
+    weights: Float[Array, "state_dim num_components"]
+    means: Float[Array, "state_dim num_components emission_dim"]
+    covs: Float[Array, "state_dim num_components emission_dim emission_dim"]
 
 
 class GaussianMixtureHMMEmissions(HMMEmissions):
@@ -80,9 +89,11 @@ class GaussianMixtureHMMEmissions(HMMEmissions):
 
         # Only use the values above if the user hasn't specified their own
         default = lambda x, x0: x if x is not None else x0
-        params = dict(weights=default(emission_weights, _emission_weights),
-                      means=default(emission_means, _emission_means),
-                      covs=default(emission_covariances, _emission_covs))
+        params = ParamsGaussianMixtureHMMEmissions(
+                    weights=default(emission_weights, _emission_weights),
+                    means=default(emission_means, _emission_means),
+                    covs=default(emission_covariances, _emission_covs)
+                    )
         props = dict(weights=ParameterProperties(constrainer=tfb.SoftmaxCentered()),
                      means=ParameterProperties(),
                      covs=ParameterProperties(constrainer=tfb.Invert(PSDToRealBijector)))
@@ -90,23 +101,23 @@ class GaussianMixtureHMMEmissions(HMMEmissions):
 
     def distribution(self, params, state, inputs=None):
         return tfd.MixtureSameFamily(
-            mixture_distribution=tfd.Categorical(probs=params['weights'][state]),
+            mixture_distribution=tfd.Categorical(probs=params.weights[state]),
             components_distribution=tfd.MultivariateNormalFullCovariance(
-                loc=params['means'][state], covariance_matrix=params['covs'][state]))
+                loc=params.means[state], covariance_matrix=params.covs[state]))
 
     def log_prior(self, params):
         lp = tfd.Dirichlet(self.emission_weights_concentration).log_prob(
-            params['weights']).sum()
+            params.weights).sum()
         lp += NormalInverseWishart(self.emission_prior_mean, self.emission_prior_mean_concentration,
                                    self.emission_prior_df, self.emission_prior_scale).log_prob(
-            (params['covs'], params['means'])).sum()
+            (params.covs, params.means)).sum()
         return lp
 
     def collect_suff_stats(self, params, posterior, emissions, inputs=None):
         def prob_fn(x):
             logprobs = vmap(lambda mus, sigmas, weights: tfd.MultivariateNormalFullCovariance(
                 loc=mus, covariance_matrix=sigmas).log_prob(x) + jnp.log(weights))(
-                    params['means'], params['covs'], params['weights'])
+                    params.means, params.covs, params.weights)
             logprobs = logprobs - logsumexp(logprobs, axis=-1, keepdims=True)
             return jnp.exp(logprobs)
 
@@ -144,10 +155,17 @@ class GaussianMixtureHMMEmissions(HMMEmissions):
         emission_stats = pytree_sum(batch_stats, axis=0)
         weights, means, covs = vmap(_single_m_step)(
             emission_stats['Sx'], emission_stats['SxxT'], emission_stats['N'])
-        params['weights'] = weights
-        params['means'] = means
-        params['covs'] = covs
+        params.weights = weights
+        params.means = means
+        params.covs = covs
         return params, m_step_state
+
+
+@chex.dataclass
+class ParamsDiagonalGaussianMixtureHMMEmissions:
+    weights: Float[Array, "state_dim num_components"]
+    means: Float[Array, "state_dim num_components emission_dim"]
+    scale_diags: Float[Array, "state_dim num_components emission_dim"]
 
 
 class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
@@ -205,9 +223,11 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
 
         # Only use the values above if the user hasn't specified their own
         default = lambda x, x0: x if x is not None else x0
-        params = dict(weights=default(emission_weights, _emission_weights),
-                      means=default(emission_means, _emission_means),
-                      scale_diags=default(emission_scale_diags, _emission_scale_diags))
+        params = ParamsDiagonalGaussianMixtureHMMEmissions(
+                    weights=default(emission_weights, _emission_weights),
+                    means=default(emission_means, _emission_means),
+                    scale_diags=default(emission_scale_diags, _emission_scale_diags)
+                    )
         props = dict(weights=ParameterProperties(constrainer=tfb.SoftmaxCentered()),
                      means=ParameterProperties(),
                      scale_diags=ParameterProperties(constrainer=tfb.Softplus()))
@@ -215,17 +235,17 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
 
     def distribution(self, params, state, inputs=None):
         return tfd.MixtureSameFamily(
-            mixture_distribution=tfd.Categorical(probs=params['weights'][state]),
+            mixture_distribution=tfd.Categorical(probs=params.weights[state]),
             components_distribution=tfd.MultivariateNormalDiag(
-                loc=params['means'][state],
-                scale_diag=params['scale_diags'][state]))
+                loc=params.means[state],
+                scale_diag=params.scale_diags[state]))
 
     def log_prior(self, params):
         lp = tfd.Dirichlet(self.emission_weights_concentration).log_prob(
-            params['weights']).sum()
+            params.weights).sum()
         lp += NormalInverseGamma(self.emission_prior_mean, self.emission_prior_mean_concentration,
                                    self.emission_prior_shape, self.emission_prior_scale).log_prob(
-            (params['scale_diags']**2, params['means'])).sum()
+            (params.scale_diags**2, params.means)).sum()
         return lp
 
     # Expectation-maximization (EM) code
@@ -234,8 +254,8 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
         def prob_fn(x):
             logprobs = vmap(lambda mus, sigmas, weights: tfd.MultivariateNormalDiag(
                 loc=mus, scale_diag=sigmas).log_prob(x) + jnp.log(weights))(
-                    params['means'], params['scale_diags'],
-                    params['weights'])
+                    params.means, params.scale_diags,
+                    params.weights)
             logprobs = logprobs - logsumexp(logprobs, axis=-1, keepdims=True)
             return jnp.exp(logprobs)
 
@@ -276,10 +296,17 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
         emission_stats = pytree_sum(batch_stats, axis=0)
         weights, means, scale_diags = vmap(_single_m_step)(
             emission_stats['Sx'], emission_stats['Sxsq'], emission_stats['N'])
-        params['weights'] = weights
-        params['means'] = means
-        params['scale_diags'] = scale_diags
+        params.weights = weights
+        params.means = means
+        params.scale_diags = scale_diags
         return params, m_step_state
+
+
+@chex.dataclass
+class ParamsGaussianMixtureHMM:
+    initial: ParamsStandardHMMTransitions
+    transitions: ParamsStandardHMMTransitions
+    emissions: ParamsGaussianMixtureHMMEmissions
 
 
 class GaussianMixtureHMM(HMM):
@@ -346,7 +373,7 @@ class GaussianMixtureHMM(HMM):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:
@@ -358,11 +385,17 @@ class GaussianMixtureHMM(HMM):
         params["initial"], props["initial"] = self.initial_component.initialize(key1, method=method, initial_probs=initial_probs)
         params["transitions"], props["transitions"] = self.transition_component.initialize(key2, method=method, transition_matrix=transition_matrix)
         params["emissions"], props["emissions"] = self.emission_component.initialize(key3, method=method, emission_weights=emission_weights, emission_means=emission_means, emission_covariances=emission_covariances, emissions=emissions)
-        return params, props
+        return ParamsGaussianMixtureHMM(**params), props
+
+
+@chex.dataclass
+class ParamsDiagonalGaussianMixtureHMM:
+    initial: ParamsStandardHMMTransitions
+    transitions: ParamsStandardHMMTransitions
+    emissions: ParamsDiagonalGaussianMixtureHMMEmissions
 
 
 class DiagonalGaussianMixtureHMM(HMM):
-
     def __init__(self,
                  num_states,
                  num_components,
@@ -430,7 +463,7 @@ class DiagonalGaussianMixtureHMM(HMM):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:
@@ -442,4 +475,4 @@ class DiagonalGaussianMixtureHMM(HMM):
         params["initial"], props["initial"] = self.initial_component.initialize(key1, method=method, initial_probs=initial_probs)
         params["transitions"], props["transitions"] = self.transition_component.initialize(key2, method=method, transition_matrix=transition_matrix)
         params["emissions"], props["emissions"] = self.emission_component.initialize(key3, method=method, emission_weights=emission_weights, emission_means=emission_means, emission_scale_diags=emission_scale_diags, emissions=emissions)
-        return params, props
+        return ParamsDiagonalGaussianMixtureHMM(**params), props

--- a/dynamax/hmm/models/linreg_hmm.py
+++ b/dynamax/hmm/models/linreg_hmm.py
@@ -1,15 +1,23 @@
 import jax.numpy as jnp
 import jax.random as jr
 from jax import vmap
+import chex
+from jaxtyping import Float, Array
 from dynamax.hmm.models.abstractions import HMM, HMMEmissions
-from dynamax.hmm.models.initial import StandardHMMInitialState
-from dynamax.hmm.models.transitions import StandardHMMTransitions
+from dynamax.hmm.models.initial import StandardHMMInitialState, ParamsStandardHMMInitialState
+from dynamax.hmm.models.transitions import StandardHMMTransitions, ParamsStandardHMMTransitions
 from dynamax.parameters import ParameterProperties
 from dynamax.utils import PSDToRealBijector, pytree_sum
 from tensorflow_probability.substrates import jax as tfp
 
 tfd = tfp.distributions
 tfb = tfp.bijectors
+
+@chex.dataclass
+class ParamsLinearRegressionHMMEmissions:
+    weights: Float[Array, "state_dim emission_dim input_dim"]
+    biases: Float[Array, "state_dim emission_dim"]
+    covs: Float[Array, "state_dim emission_dim emission_dim"]
 
 
 class LinearRegressionHMMEmissions(HMMEmissions):
@@ -61,9 +69,11 @@ class LinearRegressionHMMEmissions(HMMEmissions):
 
         # Only use the values above if the user hasn't specified their own
         default = lambda x, x0: x if x is not None else x0
-        params = dict(weights=default(emission_weights, _emission_weights),
-                      biases=default(emission_biases, _emission_biases),
-                      covs=default(emission_covariances, _emission_covs))
+        params = ParamsLinearRegressionHMMEmissions(
+                    weights=default(emission_weights, _emission_weights),
+                    biases=default(emission_biases, _emission_biases),
+                    covs=default(emission_covariances, _emission_covs)
+                    )
         props = dict(weights=ParameterProperties(),
                      biases=ParameterProperties(),
                      covs=ParameterProperties(constrainer=tfb.Invert(PSDToRealBijector)))
@@ -115,10 +125,17 @@ class LinearRegressionHMMEmissions(HMMEmissions):
 
         emission_stats = pytree_sum(batch_stats, axis=0)
         As, bs, Sigmas = vmap(_single_m_step)(emission_stats)
-        params["weights"] = As
-        params["biases"] = bs
-        params["covs"] = Sigmas
+        params.weights = As
+        params.biases = bs
+        params.covs = Sigmas
         return params, m_step_state
+
+
+@chex.dataclass
+class ParamsLinearRegressionHMM:
+    initial: ParamsStandardHMMInitialState
+    transitions: ParamsStandardHMMTransitions
+    emissions: ParamsLinearRegressionHMMEmissions
 
 
 class LinearRegressionHMM(HMM):
@@ -179,4 +196,4 @@ class LinearRegressionHMM(HMM):
         params["initial"], props["initial"] = self.initial_component.initialize(key1, method=method, initial_probs=initial_probs)
         params["transitions"], props["transitions"] = self.transition_component.initialize(key2, method=method, transition_matrix=transition_matrix)
         params["emissions"], props["emissions"] = self.emission_component.initialize(key3, method=method, emission_weights=emission_weights, emission_biases=emission_biases, emission_covariances=emission_covariances, emissions=emissions)
-        return params, props
+        return ParamsLinearRegressionHMM(**params), props

--- a/dynamax/hmm/models/linreg_hmm.py
+++ b/dynamax/hmm/models/linreg_hmm.py
@@ -184,7 +184,7 @@ class LinearRegressionHMM(HMM):
             emissions (array, optional): emissions for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:

--- a/dynamax/hmm/models/logistic_regression_hmm.py
+++ b/dynamax/hmm/models/logistic_regression_hmm.py
@@ -2,11 +2,19 @@ import jax.numpy as jnp
 import jax.random as jr
 import tensorflow_probability.substrates.jax.distributions as tfd
 import tensorflow_probability.substrates.jax.bijectors as tfb
+import chex
+from jaxtyping import Float, Array
 from dynamax.parameters import ParameterProperties
 from dynamax.hmm.models.abstractions import HMM, HMMEmissions
-from dynamax.hmm.models.initial import StandardHMMInitialState
-from dynamax.hmm.models.transitions import StandardHMMTransitions
+from dynamax.hmm.models.initial import StandardHMMInitialState, ParamsStandardHMMInitialState
+from dynamax.hmm.models.transitions import StandardHMMTransitions, ParamsStandardHMMTransitions
 import optax
+
+
+@chex.dataclass
+class ParamsLogisticRegressionHMMEmissions:
+    weights: Float[Array, "state_dim input_dim"]
+    biases: Float[Array, "state_dim"]
 
 
 class LogisticRegressionHMMEmissions(HMMEmissions):
@@ -61,8 +69,10 @@ class LogisticRegressionHMMEmissions(HMMEmissions):
 
         # Only use the values above if the user hasn't specified their own
         default = lambda x, x0: x if x is not None else x0
-        params = dict(weights=default(emission_weights, _emission_weights),
-                      biases=default(emission_biases, _emission_biases))
+        params = ParamsLogisticRegressionHMMEmissions(
+                    weights=default(emission_weights, _emission_weights),
+                    biases=default(emission_biases, _emission_biases)
+                    )
         props = dict(weights=ParameterProperties(),
                      biases=ParameterProperties())
         return params, props
@@ -75,6 +85,13 @@ class LogisticRegressionHMMEmissions(HMMEmissions):
         logits += params['biases'][state]
         return tfd.Bernoulli(logits=logits)
 
+
+@chex.dataclass
+class ParamsLogisticRegressionHMM:
+    initial: ParamsStandardHMMInitialState
+    transitions: ParamsStandardHMMTransitions
+    emissions: ParamsLogisticRegressionHMMEmissions
+    
 
 class LogisticRegressionHMM(HMM):
     def __init__(self,
@@ -135,4 +152,4 @@ class LogisticRegressionHMM(HMM):
         params["initial"], props["initial"] = self.initial_component.initialize(key1, method=method, initial_probs=initial_probs)
         params["transitions"], props["transitions"] = self.transition_component.initialize(key2, method=method, transition_matrix=transition_matrix)
         params["emissions"], props["emissions"] = self.emission_component.initialize(key3, method=method, emission_weights=emission_weights, emission_biases=emission_biases, emissions=emissions, inputs=inputs)
-        return params, props
+        return ParamsLogisticRegressionHMM(**params), props

--- a/dynamax/hmm/models/logistic_regression_hmm.py
+++ b/dynamax/hmm/models/logistic_regression_hmm.py
@@ -140,7 +140,7 @@ class LogisticRegressionHMM(HMM):
             inputs (array, optional): inputs for initializing the parameters with kmeans. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:

--- a/dynamax/hmm/models/multinomial_hmm.py
+++ b/dynamax/hmm/models/multinomial_hmm.py
@@ -119,7 +119,7 @@ class MultinomialHMM(HMM):
             emission_probs (array, optional): manually specified emission probabilities. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:

--- a/dynamax/hmm/models/multinomial_hmm.py
+++ b/dynamax/hmm/models/multinomial_hmm.py
@@ -65,7 +65,7 @@ class MultinomialHMMEmissions(HMMEmissions):
     def m_step(self, params, props, batch_stats, m_step_state):
         if props['probs'].trainable:
             emission_stats = pytree_sum(batch_stats, axis=0)
-            params['probs'] = tfd.Dirichlet(
+            params.probs = tfd.Dirichlet(
                 self.emission_prior_concentration + emission_stats['sum_x']).mode()
         return params, m_step_state
 

--- a/dynamax/hmm/models/poisson_hmm.py
+++ b/dynamax/hmm/models/poisson_hmm.py
@@ -137,7 +137,7 @@ class PoissonHMM(HMM):
             emission_rates (array, optional): manually specified emission rates. Defaults to None.
 
         Returns:
-            params: a nested dictionary of arrays containing the model parameters.
+            params: nested dataclasses of arrays containing model parameters.
             props: a nested dictionary of ParameterProperties to specify parameter constraints and whether or not they should be trained.
         """
         if key is not None:

--- a/dynamax/hmm/models/test_models.py
+++ b/dynamax/hmm/models/test_models.py
@@ -9,10 +9,6 @@ from dynamax.utils import ensure_array_has_batch_dim, monotonically_increasing
 
 NUM_TIMESTEPS = 100
 
-@chex.dataclass
-class HMMParamsBernoulli:
-    num_states: int
-    emission_dim: int
 
 @chex.dataclass
 class HMMParamsCategorical:

--- a/dynamax/hmm/models/test_models.py
+++ b/dynamax/hmm/models/test_models.py
@@ -10,18 +10,6 @@ from dynamax.utils import ensure_array_has_batch_dim, monotonically_increasing
 NUM_TIMESTEPS = 100
 
 
-@chex.dataclass
-class HMMParamsCategorical:
-    num_states: int
-    emission_dim: int
-    num_classes: int
-
-@chex.dataclass
-class HMMParamsCategoricalRegression:
-    num_states: int
-    num_classes: int
-    covariate_dim: int
-
 CONFIGS = [
     (models.BernoulliHMM, dict(num_states=4, emission_dim=3), None),
     (models.CategoricalHMM, dict(num_states=4, emission_dim=3, num_classes=5), None),

--- a/dynamax/hmm/models/test_models.py
+++ b/dynamax/hmm/models/test_models.py
@@ -7,7 +7,7 @@ from jax import vmap
 import dynamax.hmm.models as models
 from dynamax.utils import ensure_array_has_batch_dim, monotonically_increasing
 
-NUM_TIMESTEPS = 100
+NUM_TIMESTEPS = 50
 
 
 CONFIGS = [
@@ -45,9 +45,9 @@ def test_categorical_hmm_viterbi():
     # From http://en.wikipedia.org/wiki/Viterbi_algorithm:
     hmm = models.CategoricalHMM(num_states=2, emission_dim=1, num_classes=3)
     params, props = hmm.initialize(jr.PRNGKey(0))
-    params['initial']['probs'] = jnp.array([0.6, 0.4])
-    params['transitions']['transition_matrix'] = jnp.array([[0.7, 0.3], [0.4, 0.6]])
-    params['emissions']['probs'] = jnp.array([[0.1, 0.4, 0.5], [0.6, 0.3, 0.1]]).reshape(2, 1, 3)
+    params.initial.probs = jnp.array([0.6, 0.4])
+    params.transitions.transition_matrix = jnp.array([[0.7, 0.3], [0.4, 0.6]])
+    params.emissions.probs = jnp.array([[0.1, 0.4, 0.5], [0.6, 0.3, 0.1]]).reshape(2, 1, 3)
     emissions = jnp.arange(3).reshape(3, 1)
     state_sequence = hmm.most_likely_states(params, emissions)
     assert jnp.allclose(jnp.squeeze(state_sequence), jnp.array([1, 0, 0]))
@@ -61,11 +61,11 @@ def test_gmm_hmm_vs_gmm_diag_hmm(key=jr.PRNGKey(0), num_states=4, num_components
     full_params, _ = full_hmm.initialize(key2)
 
     # Copy over a few params
-    full_params['initial']['probs'] = diag_params['initial']['probs']
-    full_params['transitions']['transition_matrix'] = diag_params['transitions']['transition_matrix']
-    full_params['emissions']['weights'] = diag_params['emissions']['weights']
-    full_params['emissions']['means'] = diag_params['emissions']['means']
-    full_params['emissions']['covs'] = vmap(lambda ss: vmap(lambda s: jnp.diag(s**2))(ss))(diag_params['emissions']['scale_diags'])
+    full_params.initial.probs = diag_params.initial.probs
+    full_params.transitions.transition_matrix = diag_params.transitions.transition_matrix
+    full_params.emissions.weights = diag_params.emissions.weights
+    full_params.emissions.means = diag_params.emissions.means
+    full_params.emissions.covs = vmap(lambda ss: vmap(lambda s: jnp.diag(s**2))(ss))(diag_params.emissions.scale_diags)
 
     states_diag, emissions_diag = diag_hmm.sample(diag_params, key3, NUM_TIMESTEPS)
     states_full, emissions_full = full_hmm.sample(full_params, key3, NUM_TIMESTEPS)

--- a/dynamax/hmm/models/test_models.py
+++ b/dynamax/hmm/models/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 from datetime import datetime
+import chex
 import jax.numpy as jnp
 import jax.random as jr
 from jax import vmap
@@ -7,6 +8,23 @@ import dynamax.hmm.models as models
 from dynamax.utils import ensure_array_has_batch_dim, monotonically_increasing
 
 NUM_TIMESTEPS = 100
+
+@chex.dataclass
+class HMMParamsBernoulli:
+    num_states: int
+    emission_dim: int
+
+@chex.dataclass
+class HMMParamsCategorical:
+    num_states: int
+    emission_dim: int
+    num_classes: int
+
+@chex.dataclass
+class HMMParamsCategoricalRegression:
+    num_states: int
+    num_classes: int
+    covariate_dim: int
 
 CONFIGS = [
     (models.BernoulliHMM, dict(num_states=4, emission_dim=3), None),

--- a/dynamax/linear_gaussian_ssm/inference_test.py
+++ b/dynamax/linear_gaussian_ssm/inference_test.py
@@ -53,12 +53,12 @@ def test_kalman(num_timesteps=5, seed=0):
     lgssm = LinearGaussianSSM(state_dim, emission_dim)
     params, _ = lgssm.initialize(init_key)
 
-    params['initial']['mean'] = mu0
-    params['initial']['cov'] = Sigma0
-    params['dynamics']['weights'] = F
-    params['dynamics']['cov'] = Q
-    params['emissions']['weights'] = H
-    params['emissions']['cov'] = R
+    params.initial.mean = mu0
+    params.initial.cov = Sigma0
+    params.dynamics.weights = F
+    params.dynamics.cov = Q
+    params.emissions.weights = H
+    params.emissions.cov = R
 
     # Sample data and compute posterior
     _, emissions = lgssm.sample(params, sample_key, num_timesteps)
@@ -99,12 +99,12 @@ def test_posterior_sampler():
     lgssm = LinearGaussianSSM(state_dim, emission_dim)
     params, _ = lgssm.initialize(key)
 
-    params['initial']['mean'] = mu0
-    params['initial']['cov'] = Sigma0
-    params['dynamics']['weights'] = F
-    params['dynamics']['cov'] = Q
-    params['emissions']['weights'] = H
-    params['emissions']['cov'] = R
+    params.initial.mean = mu0
+    params.initial.cov = Sigma0
+    params.dynamics.weights = F
+    params.dynamics.cov = Q
+    params.emissions.weights = H
+    params.emissions.cov = R
 
     # Generate true observation
     sample_key, key = jr.split(key)

--- a/dynamax/linear_gaussian_ssm/linear_gaussian_ssm.py
+++ b/dynamax/linear_gaussian_ssm/linear_gaussian_ssm.py
@@ -228,17 +228,23 @@ class LinearGaussianSSM(SSM):
         params: ParamsLGSSMMoment
     ) -> ParamsLGSSM:
         """Convert params from inference container to dict."""
-        return dict(
-            initial=dict(mean=params.initial_mean,
-                         cov=params.initial_covariance),
-            dynamics=dict(weights=params.dynamics_weights,
-                          bias=params.dynamics_bias,
-                          input_weights=params.dynamics_input_weights,
-                          cov=params.dynamics_covariance),
-            emissions=dict(weights=params.emission_weights,
-                           bias=params.emission_bias,
-                           input_weights=params.emission_input_weights,
-                           cov=params.emission_covariance)
+        return ParamsLGSSM(
+            initial=ParamsLGSSMInitial(
+                        mean=params.initial_mean,
+                        cov=params.initial_covariance
+                        ),
+            dynamics=ParamsLGSSMDynamics(
+                        weights=params.dynamics_weights,
+                        bias=params.dynamics_bias,
+                        input_weights=params.dynamics_input_weights,
+                        cov=params.dynamics_covariance
+                        ),
+            emissions=ParamsLGSSMEmissions(
+                        weights=params.emission_weights,
+                        bias=params.emission_bias,
+                        input_weights=params.emission_input_weights,
+                        cov=params.emission_covariance
+                        )
             )
        
 

--- a/dynamax/linear_gaussian_ssm/linear_gaussian_ssm_conjugate.py
+++ b/dynamax/linear_gaussian_ssm/linear_gaussian_ssm_conjugate.py
@@ -8,7 +8,11 @@ from dynamax.distributions import MatrixNormalInverseWishart as MNIW
 from dynamax.distributions import NormalInverseWishart as NIW
 from dynamax.distributions import mniw_posterior_update, niw_posterior_update
 from dynamax.linear_gaussian_ssm.inference import ParamsLGSSMMoment, lgssm_posterior_sample
-from dynamax.linear_gaussian_ssm.linear_gaussian_ssm import LinearGaussianSSM
+from dynamax.linear_gaussian_ssm.linear_gaussian_ssm import (LinearGaussianSSM,
+                                                             ParamsLGSSM,
+                                                             ParamsLGSSMInitial,
+                                                             ParamsLGSSMDynamics,
+                                                             ParamsLGSSMEmissions)
 
 
 
@@ -108,10 +112,10 @@ class LinearGaussianConjugateSSM(LinearGaussianSSM):
         D, d = (HD[:, self.state_dim:-1], HD[:, -1]) if self.has_emissions_bias \
             else (HD[:, self.state_dim:], jnp.zeros(self.emission_dim))
 
-        params = dict(
-            initial=dict(mean=m, cov=S),
-            dynamics=dict(weights=F, bias=b, input_weights=B, cov=Q),
-            emissions=dict(weights=H, bias=d, input_weights=D, cov=R)
+        params = ParamsLGSSM(
+            initial=ParamsLGSSMInitial(mean=m, cov=S),
+            dynamics=ParamsLGSSMDynamics(weights=F, bias=b, input_weights=B, cov=Q),
+            emissions=ParamsLGSSMEmissions(weights=H, bias=d, input_weights=D, cov=R)
         )
         return params, m_step_state
 

--- a/dynamax/parameters_test.py
+++ b/dynamax/parameters_test.py
@@ -7,10 +7,10 @@ from jaxtyping import Float, Array
 from dynamax.parameters import ParameterProperties, to_unconstrained, from_unconstrained
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
+
 @chex.dataclass
 class InitialParams:
     probs: Float[Array, "state_dim"]
-
 
 @chex.dataclass
 class TransitionsParams:

--- a/dynamax/parameters_test.py
+++ b/dynamax/parameters_test.py
@@ -1,15 +1,37 @@
+import chex 
 import jax.numpy as jnp
 from jax.tree_util import tree_map, tree_leaves
+
+from jaxtyping import Float, Array
 
 from dynamax.parameters import ParameterProperties, to_unconstrained, from_unconstrained
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
+@chex.dataclass
+class InitialParams:
+    probs: Float[Array, "state_dim"]
+
+
+@chex.dataclass
+class TransitionsParams:
+    transition_matrix: Float[Array, "state_dim state_dim"]
+
+@chex.dataclass
+class EmissionsParams:
+    means: Float[Array, "state_dim emission_dim"]
+    scales: Float[Array, "state_dim emission_dim"]
+
+@chex.dataclass
+class Params:
+    initial: InitialParams
+    transitions: TransitionsParams
+    emissions: EmissionsParams
 
 def test_parameter_tofrom_unconstrained():
-    params = dict(
-        initial=dict(probs=jnp.ones(3) / 3.0),
-        transitions=dict(transition_matrix=0.9 * jnp.eye(3) + 0.1 * jnp.ones((3, 3)) / 3),
-        emissions=dict(means=jnp.zeros((3, 2)), scales=jnp.ones((3, 2)))
+    params = Params(
+        initial=InitialParams(probs=jnp.ones(3) / 3.0),
+        transitions=TransitionsParams(transition_matrix=0.9 * jnp.eye(3) + 0.1 * jnp.ones((3, 3)) / 3),
+        emissions=EmissionsParams(means=jnp.zeros((3, 2)), scales=jnp.ones((3, 2)))
     )
 
     param_props = dict(


### PR DESCRIPTION
## Param dict --> dataclass
This PR changes hmm parameters to be stored in nested dataclasses rather than dictionaries.

This introduces four different types of dataclass, one for initial params, one for transition params, one for emissions params and the top level class which houses an instance of each of the above. Something like:
```python
@chex.dataclass
class InitialParams:
    probs: Float[Array, "state_dim"]

@chex.dataclass
class TransitionsParams:
    transition_matrix: Float[Array, "state_dim state_dim"]

@chex.dataclass
class EmissionsParams:
    means: Float[Array, "state_dim emission_dim"]
    scales: Float[Array, "state_dim emission_dim"]

@chex.dataclass
class Params:
    initial: InitialParams
    transitions: TransitionsParams
    emissions: EmissionsParams
```
This PR defines the appropriate dataclasses and updates the relevant model/emission objects to use/return a dataclass rather than a nested dictionary object. The naming convention is to prepend "Params" to the relevant class: `Params*`, e.g. `ParamsPoissonHMMEmissions`, `ParamsPoissonHMM`, `ParamsStandardHMMInitialState`, ...

The fields of a dataclass can be accessed with either 'square-bracket notation' like a dictionary (e.g. `params['probs']`) or with 'dot notation' (e.g. `params.probs`). However only the dot notation can be used if the value of the field is being set. Therefore, where necessary, square-bracket access has been replaced by dot access.

## to/from unconstrained
To reflect change to using dataclasses, the `to_unconstrained` and `from_unconstrained` functions have been updated and their behaviour has slightly changed.

The function `to_unconstrained` previously returned two dictionaries, `unc_params` and `fixed_params`, containing the unconstrained and fixed parameters respectively. It now returns the unconstrained parameters in a dictionary (as before) alongside the original `params` dataclass which contains all parameters (not just the fixed parameters).

The function `from_unconstrained` takes a  dictionary of unconstrained parameters (as before) as well as a dataclass containing all of the parameters (`orig_params`) and for each parameter in `unc_params` replaces the corresponding leaf in `orig_params` with the appropriately constrained value from `unc_params`.

## Possible future changes/additions:
At present all the tests in `hmm/` are passing in this branch but this change has most likely broken almost all of the hmm notebooks, fixing them is a priority.

Other possible updates include:
- Parameter properties are still in a dictionary rather than a dataclass.
     - The question of how to handle properties is still a bit up in the air and so this can be left for the time being.
- Combine Parameter classes where possible.
     - At present there is some redundancy, e.g. ` ParamsLinearRegressionHMM` and `ParamsLinearAutoregressiveHMM` have identical fields and types and should perhaps be combined.
