### PR TITLE
Add wrapper to linear solve.

### DIFF
--- a/dynamax/generalized_gaussian_ssm/inference.py
+++ b/dynamax/generalized_gaussian_ssm/inference.py
@@ -2,10 +2,13 @@ from itertools import product
 from numpy.polynomial.hermite_e import hermegauss
 from jax import jacfwd, vmap, lax
 import jax.numpy as jnp
+from jax import scipy as jsc
+from jax import lax
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN
 from jaxtyping import Array, Float
 from typing import NamedTuple, Optional, Union, Callable
 
+from dynamax.utils.utils import linear_solve
 from dynamax.generalized_gaussian_ssm.models import ParamsGGSSM
 from dynamax.linear_gaussian_ssm.inference import PosteriorGSSMFiltered, PosteriorGSSMSmoothed
 
@@ -159,7 +162,7 @@ def _condition_on(m, P, y_cond_mean, y_cond_cov, u, y, g_ev, g_cov, num_iter, em
         S = g_ev(Cov_Y, prior_mean, prior_cov) + g_cov(m_Y, m_Y, prior_mean, prior_cov)
         log_likelihood = emission_dist(yhat, S).log_prob(jnp.atleast_1d(y)).sum()
         C = g_cov(identity_fn, m_Y, prior_mean, prior_cov)
-        K = jnp.linalg.solve(S, C.T).T
+        K = linear_solve(S, C.T).T
         posterior_mean = prior_mean + K @ (y - yhat)
         posterior_cov = prior_cov - K @ S @ K.T
         return (posterior_mean, posterior_cov), log_likelihood
@@ -192,7 +195,7 @@ def _statistical_linear_regression(mu, Sigma, m, S, C):
         b (D_obs):
         Omega (D_obs, D_obs):
     """
-    A = jnp.linalg.solve(Sigma.T, C).T
+    A = linear_solve(Sigma.T, C).T
     b = m - A @ mu
     Omega = S - A @ Sigma @ A.T
     return A, b, Omega
@@ -326,7 +329,7 @@ def conditional_moments_gaussian_smoother(
 
         # Prediction step
         pred_mean, pred_cov, pred_cross = _predict(filtered_mean, filtered_cov, f, Q, u, g_ev, g_cov)
-        G = jnp.linalg.solve(pred_cov, pred_cross.T).T
+        G = linear_solve(pred_cov, pred_cross.T).T
 
         # Compute smoothed mean and covariance
         smoothed_mean = filtered_mean + G @ (smoothed_mean_next - pred_mean)

--- a/dynamax/linear_gaussian_ssm/inference.py
+++ b/dynamax/linear_gaussian_ssm/inference.py
@@ -1,5 +1,6 @@
 import jax.numpy as jnp
 import jax.random as jr
+from jax import scipy as jsc
 from jax import lax
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN
 from functools import wraps
@@ -8,6 +9,7 @@ import inspect
 from jaxtyping import Array, Float
 from typing import NamedTuple, Optional, Union
 
+from dynamax.utils.utils import linear_solve
 from dynamax.parameters import ParameterProperties
 from dynamax.types import PRNGKey, Scalar
 
@@ -169,7 +171,7 @@ def _condition_on(m, P, H, D, d, R, u, y):
     """
     # Compute the Kalman gain
     S = R + H @ P @ H.T
-    K = jnp.linalg.solve(S, H @ P).T
+    K = linear_solve(S, H @ P).T
     Sigma_cond = P - K @ S @ K.T
     mu_cond = m + K @ (y - D @ u - d - H @ m)
     return mu_cond, Sigma_cond
@@ -322,7 +324,7 @@ def lgssm_smoother(
 
         # This is like the Kalman gain but in reverse
         # See Eq 8.11 of Saarka's "Bayesian Filtering and Smoothing"
-        G = jnp.linalg.solve(Q + F @ filtered_cov @ F.T, F @ filtered_cov).T
+        G = linear_solve(Q + F @ filtered_cov @ F.T, F @ filtered_cov).T
 
         # Compute the smoothed mean and covariance
         smoothed_mean = filtered_mean + G @ (smoothed_mean_next - F @ filtered_mean - B @ u - b)

--- a/dynamax/linear_gaussian_ssm/info_inference.py
+++ b/dynamax/linear_gaussian_ssm/info_inference.py
@@ -1,8 +1,11 @@
 import jax.numpy as jnp
+from jax import scipy as jsc
 from jax import lax, vmap, value_and_grad
 from jax.scipy.linalg import solve_triangular
 from jaxtyping import Array, Float
 from typing import NamedTuple, Optional
+
+from dynamax.utils.utils import linear_solve
 
 
 class ParamsLGSSMInfo(NamedTuple):
@@ -57,7 +60,7 @@ def info_to_moment_form(etas, Lambdas):
         means (N,D)
         covs (N,D,D)
     """
-    means = vmap(jnp.linalg.solve)(Lambdas, etas)
+    means = vmap(lambda A, b:linear_solve(A, b))(Lambdas, etas)
     covs = jnp.linalg.inv(Lambdas)
     return means, covs
 
@@ -79,7 +82,7 @@ def _mvn_info_log_prob(eta, Lambda, x):
     """
     D = len(Lambda)
     lp = x.T @ eta - 0.5 * x.T @ Lambda @ x
-    lp += -0.5 * eta.T @ jnp.linalg.solve(Lambda, eta)
+    lp += -0.5 * eta.T @ linear_solve(Lambda, eta)
     sign, logdet = jnp.linalg.slogdet(Lambda)
     lp += -0.5 * (D * jnp.log(2 * jnp.pi) - sign * logdet)
     return lp
@@ -118,7 +121,7 @@ def _info_predict(eta, Lambda, F, Q_prec, B, u, b):
         eta_pred (D_hid,): predicted precision weighted mean.
         Lambda_pred (D_hid,D_hid): predicted precision.
     """
-    K = jnp.linalg.solve(Lambda + F.T @ Q_prec @ F, F.T @ Q_prec).T
+    K = linear_solve(Lambda + F.T @ Q_prec @ F, F.T @ Q_prec).T
     I = jnp.eye(F.shape[0])
     ## This version should be more stable than:
     # Lambda_pred = (I - K @ F.T) @ Q_prec
@@ -260,7 +263,7 @@ def lgssm_info_smoother(
 
         # This is the information form version of the 'reverse' Kalman gain
         # See Eq 8.11 of Saarka's "Bayesian Filtering and Smoothing"
-        G = jnp.linalg.solve(Q_prec + smoothed_prec_next - pred_prec, Q_prec @ F)
+        G = linear_solve(Q_prec + smoothed_prec_next - pred_prec, Q_prec @ F)
 
         # Compute the smoothed parameter estimates
         smoothed_prec = filtered_prec + F.T @ Q_prec @ (F - G)
@@ -395,18 +398,18 @@ def lds_to_block_tridiag(lds, data, inputs):
     T = len(data)
 
     # diagonal blocks of precision matrix
-    J_diag = jnp.array([jnp.dot(C(t).T, jnp.linalg.solve(R(t), C(t))) for t in range(T)])
+    J_diag = jnp.array([jnp.dot(C(t).T, linear_solve(R(t), C(t))) for t in range(T)])
     J_diag = J_diag.at[0].add(jnp.linalg.inv(Q0))
-    J_diag = J_diag.at[:-1].add(jnp.array([jnp.dot(A(t).T, jnp.linalg.solve(Q(t), A(t))) for t in range(T - 1)]))
+    J_diag = J_diag.at[:-1].add(jnp.array([jnp.dot(A(t).T, linear_solve(Q(t), A(t))) for t in range(T - 1)]))
     J_diag = J_diag.at[1:].add(jnp.array([jnp.linalg.inv(Q(t)) for t in range(0, T - 1)]))
 
     # lower diagonal blocks of precision matrix
-    J_lower_diag = jnp.array([-jnp.linalg.solve(Q(t), A(t)) for t in range(T - 1)])
+    J_lower_diag = jnp.array([-linear_solve(Q(t), A(t)) for t in range(T - 1)])
 
     # linear potential
-    h = jnp.array([jnp.dot(data[t] - D(t) @ inputs[t], jnp.linalg.solve(R(t), C(t))) for t in range(T)])
-    h = h.at[0].add(jnp.linalg.solve(Q0, m0))
-    h = h.at[:-1].add(jnp.array([-jnp.dot(A(t).T, jnp.linalg.solve(Q(t), B(t) @ inputs[t])) for t in range(T - 1)]))
-    h = h.at[1:].add(jnp.array([jnp.linalg.solve(Q(t), B(t) @ inputs[t]) for t in range(T - 1)]))
+    h = jnp.array([jnp.dot(data[t] - D(t) @ inputs[t], linear_solve(R(t), C(t))) for t in range(T)])
+    h = h.at[0].add(linear_solve(Q0, m0))
+    h = h.at[:-1].add(jnp.array([-jnp.dot(A(t).T, linear_solve(Q(t), B(t) @ inputs[t])) for t in range(T - 1)]))
+    h = h.at[1:].add(jnp.array([linear_solve(Q(t), B(t) @ inputs[t]) for t in range(T - 1)]))
 
     return J_diag, J_lower_diag, h

--- a/dynamax/linear_gaussian_ssm/models.py
+++ b/dynamax/linear_gaussian_ssm/models.py
@@ -3,6 +3,7 @@ from functools import partial
 from jax import jit
 import jax.numpy as jnp
 import jax.random as jr
+from jax import scipy as jsc
 from jax.tree_util import tree_map
 from jaxtyping import Array, Float, PyTree
 import tensorflow_probability.substrates.jax.distributions as tfd
@@ -20,7 +21,7 @@ from dynamax.utils.bijectors import RealToPSDBijector
 from dynamax.utils.distributions import MatrixNormalInverseWishart as MNIW
 from dynamax.utils.distributions import NormalInverseWishart as NIW
 from dynamax.utils.distributions import mniw_posterior_update, niw_posterior_update
-from dynamax.utils.utils import pytree_stack
+from dynamax.utils.utils import pytree_stack, linear_solve
 
 class SuffStatsLGSSM(Protocol):
     """A :class:`NamedTuple` with sufficient statistics for LGSSM parameter estimation."""
@@ -339,7 +340,7 @@ class LinearGaussianSSM(SSM):
 
         def fit_linear_regression(ExxT, ExyT, EyyT, N):
             # Solve a linear regression given sufficient statistics
-            W = jnp.linalg.solve(ExxT, ExyT).T
+            W = linear_solve(ExxT, ExyT).T
             Sigma = (EyyT - W @ ExyT - ExyT.T @ W.T + W @ ExxT @ W.T) / N
             return W, Sigma
 

--- a/dynamax/linear_gaussian_ssm/models.py
+++ b/dynamax/linear_gaussian_ssm/models.py
@@ -3,7 +3,6 @@ from functools import partial
 from jax import jit
 import jax.numpy as jnp
 import jax.random as jr
-from jax import scipy as jsc
 from jax.tree_util import tree_map
 from jaxtyping import Array, Float, PyTree
 import tensorflow_probability.substrates.jax.distributions as tfd

--- a/dynamax/linear_gaussian_ssm/parallel_inference.py
+++ b/dynamax/linear_gaussian_ssm/parallel_inference.py
@@ -7,6 +7,7 @@ from jax import vmap, lax
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN
 from jaxtyping import Array, Float
 
+from dynamax.utils.utils import linear_solve
 from dynamax.linear_gaussian_ssm.inference import PosteriorGSSMFiltered, PosteriorGSSMSmoothed, ParamsLGSSM
 
 def _make_associative_filtering_elements(params, emissions):
@@ -25,7 +26,7 @@ def _make_associative_filtering_elements(params, emissions):
         m1 = params.initial.mean
         P1 = params.initial.cov
         S1 = H @ P1 @ H.T + R
-        K1 = jsc.linalg.solve(S1, H @ P1, assume_a='pos').T
+        K1 = linear_solve(S1, H @ P1).T
 
         A = jnp.zeros_like(F)
         b = m1 + K1 @ (y - H @ m1)
@@ -130,7 +131,7 @@ def _make_associative_smoothing_elements(params, filtered_means, filtered_covari
 
         Pp = F @ P @ F.T + Q
 
-        E  = jsc.linalg.solve(Pp, F @ P, assume_a='pos').T
+        E  = linear_solve(Pp, F @ P).T
         g  = m - E @ F @ m
         L  = P - E @ Pp @ E.T
         return E, g, L

--- a/dynamax/nonlinear_gaussian_ssm/inference_ekf.py
+++ b/dynamax/nonlinear_gaussian_ssm/inference_ekf.py
@@ -1,5 +1,4 @@
 import jax.numpy as jnp
-from jax import scipy as jsc
 from jax import lax
 from jax import jacfwd
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN

--- a/dynamax/nonlinear_gaussian_ssm/inference_ukf.py
+++ b/dynamax/nonlinear_gaussian_ssm/inference_ukf.py
@@ -1,10 +1,12 @@
 import jax.numpy as jnp
+from jax import scipy as jsc
 from jax import lax
 from jax import vmap
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN
 from jaxtyping import Array, Float
 from typing import NamedTuple, Optional
 
+from dynamax.utils.utils import linear_solve
 from dynamax.nonlinear_gaussian_ssm.models import  ParamsNLGSSM
 from dynamax.linear_gaussian_ssm.models import PosteriorGSSMFiltered, PosteriorGSSMSmoothed
 
@@ -129,7 +131,7 @@ def _condition_on(m, P, h, R, lamb, w_mean, w_cov, u, y):
     ll = MVN(pred_mean, pred_cov).log_prob(y)
 
     # Compute filtered mean and covariace
-    K = jnp.linalg.solve(pred_cov, pred_cross.T).T  # Filter gain
+    K = linear_solve(pred_cov, pred_cross.T).T  # Filter gain
     m_cond = m + K @ (y - pred_mean)
     P_cond = P - K @ pred_cov @ K.T
     return ll, m_cond, P_cond
@@ -243,7 +245,7 @@ def unscented_kalman_smoother(
 
         # Prediction step
         m_pred, S_pred, S_cross = _predict(filtered_mean, filtered_cov, f, Q, lamb, w_mean, w_cov, u)
-        G = jnp.linalg.solve(S_pred, S_cross.T).T
+        G = linear_solve(S_pred, S_cross.T).T
 
         # Compute smoothed mean and covariance
         smoothed_mean = filtered_mean + G @ (smoothed_mean_next - m_pred)

--- a/dynamax/nonlinear_gaussian_ssm/inference_ukf.py
+++ b/dynamax/nonlinear_gaussian_ssm/inference_ukf.py
@@ -1,5 +1,4 @@
 import jax.numpy as jnp
-from jax import scipy as jsc
 from jax import lax
 from jax import vmap
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN

--- a/dynamax/utils/distributions.py
+++ b/dynamax/utils/distributions.py
@@ -1,7 +1,6 @@
 import jax.numpy as jnp
 from jax import vmap
 from jax.scipy.linalg import solve_triangular
-from jax import scipy as jsc
 from tensorflow_probability.substrates import jax as tfp
 
 tfd = tfp.distributions

--- a/dynamax/utils/distributions.py
+++ b/dynamax/utils/distributions.py
@@ -1,10 +1,13 @@
 import jax.numpy as jnp
 from jax import vmap
 from jax.scipy.linalg import solve_triangular
+from jax import scipy as jsc
 from tensorflow_probability.substrates import jax as tfp
 
 tfd = tfp.distributions
 tfb = tfp.bijectors
+
+from dynamax.utils.utils import linear_solve
 
 
 class InverseWishart(tfd.TransformedDistribution):
@@ -317,7 +320,7 @@ def mniw_posterior_update(mniw_prior, sufficient_stats):
     Sxx = V_pri + SxxT
     Sxy = SxyT + V_pri @ M_pri.T
     Syy = SyyT + M_pri @ V_pri @ M_pri.T
-    M_pos = jnp.linalg.solve(Sxx, Sxy).T
+    M_pos = linear_solve(Sxx, Sxy).T
     V_pos = Sxx
     nu_pos = nu_pri + N
     Psi_pos = Psi_pri + Syy - M_pos @ Sxy

--- a/dynamax/utils/utils.py
+++ b/dynamax/utils/utils.py
@@ -196,3 +196,8 @@ def find_permutation(
     overlap = compute_state_overlap(z1, z2)
     _, perm = linear_sum_assignment(-overlap)
     return perm
+
+
+def linear_solve(A,b):
+    """A wrapper for coordinating the linalg solvers used in the library."""
+    return jnp.linalg.solve(A,b)


### PR DESCRIPTION
In cases where the matrix A should be is positive semidefinite, replace jnp.linalg.solve with wrapper in `utils/utils.py` so that we have control over the solver used.

For the time being the solver itself is not changed.

Note that the wrapper is only used is scenarios where I was reasonably confident that the matrix A is psd.