### PR TITLE
[FIX] Handle zeros in transition matrix, update GaussianHMM example

### DIFF
--- a/docs/notebooks/hmm/gaussian_hmm.ipynb
+++ b/docs/notebooks/hmm/gaussian_hmm.ipynb
@@ -160,7 +160,7 @@
     "\n",
     "# Specify parameters of the HMM\n",
     "initial_probs = jnp.ones(true_num_states) / true_num_states\n",
-    "transition_matrix = 0.8 * jnp.eye(true_num_states) + 0.2 * jnp.roll(jnp.eye(true_num_states), 1, axis=1)\n",
+    "transition_matrix = 0.79 * jnp.eye(true_num_states) + 0.01 + 0.16 * jnp.roll(jnp.eye(true_num_states), 1, axis=1)\n",
     "emission_means = jnp.column_stack([\n",
     "    jnp.cos(jnp.linspace(0, 2 * jnp.pi, true_num_states + 1))[:-1],\n",
     "    jnp.sin(jnp.linspace(0, 2 * jnp.pi, true_num_states + 1))[:-1],\n",

--- a/dynamax/hidden_markov_model/inference.py
+++ b/dynamax/hidden_markov_model/inference.py
@@ -289,7 +289,9 @@ def hmm_smoother(
         A = get_trans_mat(transition_matrix, transition_fn, t)
 
         # Fold in the next state (Eq. 8.2 of Saarka, 2013)
-        relative_probs_next = smoothed_probs_next / predicted_probs_next
+        # If hard 0. in predicted_probs_next, set relative_probs_next as 0. to avoid NaN values
+        relative_probs_next = jnp.where(jnp.isclose(predicted_probs_next, 0.0), 0.0,
+                                        smoothed_probs_next / predicted_probs_next)
         smoothed_probs = filtered_probs * (A @ relative_probs_next)
         smoothed_probs /= smoothed_probs.sum()
 
@@ -551,7 +553,9 @@ def _compute_sum_transition_probs(
         A = _get_params(transition_matrix, 2, t)
 
         # Compute smoothed transition probabilities (Eq. 8.4 of Saarka, 2013)
-        relative_probs_next = smoothed_probs_next / predicted_probs_next
+        # If hard 0. in predicted_probs_next, set relative_probs_next as 0. to avoid NaN values
+        relative_probs_next = jnp.where(jnp.isclose(predicted_probs_next, 0.0), 0.0,
+                                        smoothed_probs_next / predicted_probs_next)
         smoothed_trans_probs = filtered_probs[:, None] * A * relative_probs_next[None, :]
         smoothed_trans_probs /= smoothed_trans_probs.sum()
         return carry + smoothed_trans_probs, None


### PR DESCRIPTION
Closes #290 

- Updates calculation in `hmm_smoother`, `_compute_sum_transition_probs` to handle hard zeroes without cascading NaN values into posterior probabilities
- Updates the [GaussianHMM example in the docs](https://probml.github.io/dynamax/notebooks/hmm/gaussian_hmm.html) to not use a sparse transition matrix, to avoid potential user confusion.

cc @slinderman 