### PR TITLE
Symmetrize lgssm filtered covariance

### DIFF
--- a/dynamax/linear_gaussian_ssm/inference.py
+++ b/dynamax/linear_gaussian_ssm/inference.py
@@ -8,7 +8,7 @@ import inspect
 from jax.tree_util import tree_map
 from jaxtyping import Array, Float
 from typing import NamedTuple, Optional, Union, Tuple
-from dynamax.utils.utils import psd_solve
+from dynamax.utils.utils import psd_solve, symmetrize
 from dynamax.parameters import ParameterProperties
 from dynamax.types import PRNGKey, Scalar
 
@@ -220,7 +220,7 @@ def _condition_on(m, P, H, D, d, R, u, y):
     K = psd_solve(S, H @ P).T
     Sigma_cond = P - K @ S @ K.T
     mu_cond = m + K @ (y - D @ u - d - H @ m)
-    return mu_cond, Sigma_cond
+    return mu_cond, symmetrize(Sigma_cond)
 
 
 def preprocess_params_and_inputs(params, num_timesteps, inputs):

--- a/dynamax/utils/utils.py
+++ b/dynamax/utils/utils.py
@@ -202,3 +202,7 @@ def psd_solve(A,b):
     """A wrapper for coordinating the linalg solvers used in the library for psd matrices."""
     A = A + 1e-6
     return jnp.linalg.solve(A,b)
+
+def symmetrize(A):
+    """Symmetrize one or more matrices."""
+    return 0.5 * (A + jnp.swapaxes(A, -1, -2))


### PR DESCRIPTION
This PR addresses numerical instability in the LGSSM inference code (issue https://github.com/probml/dynamax/issues/317) by ensuring the covariance matrices output by `lgssm_filter` are symmetric. 

This is done by forcibly symmetrizing the output of `_condition_on`. In principle there are a few other places where one could also symmetrize (in fact, in issue https://github.com/probml/dynamax/issues/317 the asymmetry first occurs after the `_predict` step), but limiting it to `_condition_on` seemed like the least cumbersome option. 

The new code passes the following LGSSM inference tests:
```
from dynamax.linear_gaussian_ssm.inference_test import TestFilteringAndSmoothing

TestFilteringAndSmoothing.test_kalman_tfp(TestFilteringAndSmoothing)
TestFilteringAndSmoothing.test_kalman_vs_joint(TestFilteringAndSmoothing)
TestFilteringAndSmoothing.test_posterior_sampler(TestFilteringAndSmoothing)
```