### PR TITLE
Non-determinism in SKLearn KMeans initialisation

### DIFF
--- a/dynamax/hidden_markov_model/models/arhmm.py
+++ b/dynamax/hidden_markov_model/models/arhmm.py
@@ -43,7 +43,8 @@ class LinearAutoregressiveHMMEmissions(LinearRegressionHMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.emission_dim * self.num_lags))
             _emission_biases = jnp.array(km.cluster_centers_)

--- a/dynamax/hidden_markov_model/models/arhmm.py
+++ b/dynamax/hidden_markov_model/models/arhmm.py
@@ -43,8 +43,7 @@ class LinearAutoregressiveHMMEmissions(LinearRegressionHMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.emission_dim * self.num_lags))
             _emission_biases = jnp.array(km.cluster_centers_)

--- a/dynamax/hidden_markov_model/models/arhmm.py
+++ b/dynamax/hidden_markov_model/models/arhmm.py
@@ -44,7 +44,7 @@ class LinearAutoregressiveHMMEmissions(LinearRegressionHMMEmissions):
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.emission_dim * self.num_lags))
             _emission_biases = jnp.array(km.cluster_centers_)
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim)[None, :, :], (self.num_states, 1, 1))

--- a/dynamax/hidden_markov_model/models/arhmm.py
+++ b/dynamax/hidden_markov_model/models/arhmm.py
@@ -42,7 +42,8 @@ class LinearAutoregressiveHMMEmissions(LinearRegressionHMMEmissions):
         if method.lower() == "kmeans":
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
-            km = KMeans(self.num_states).fit(emissions.reshape(-1, self.emission_dim))
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.emission_dim * self.num_lags))
             _emission_biases = jnp.array(km.cluster_centers_)
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim)[None, :, :], (self.num_states, 1, 1))

--- a/dynamax/hidden_markov_model/models/arhmm.py
+++ b/dynamax/hidden_markov_model/models/arhmm.py
@@ -43,7 +43,7 @@ class LinearAutoregressiveHMMEmissions(LinearRegressionHMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.emission_dim * self.num_lags))
             _emission_biases = jnp.array(km.cluster_centers_)

--- a/dynamax/hidden_markov_model/models/arhmm.py
+++ b/dynamax/hidden_markov_model/models/arhmm.py
@@ -43,7 +43,8 @@ class LinearAutoregressiveHMMEmissions(LinearRegressionHMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.emission_dim * self.num_lags))
             _emission_biases = jnp.array(km.cluster_centers_)
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim)[None, :, :], (self.num_states, 1, 1))

--- a/dynamax/hidden_markov_model/models/gamma_hmm.py
+++ b/dynamax/hidden_markov_model/models/gamma_hmm.py
@@ -39,7 +39,8 @@ class GammaHMMEmissions(HMMEmissions):
         if method.lower() == "kmeans":
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
-            km = KMeans(self.num_states).fit(emissions.reshape(-1, 1))
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, 1))
 
             _emission_concentrations = jnp.ones((self.num_states,))
             _emission_rates = jnp.ravel(1.0 / km.cluster_centers_)

--- a/dynamax/hidden_markov_model/models/gamma_hmm.py
+++ b/dynamax/hidden_markov_model/models/gamma_hmm.py
@@ -40,7 +40,8 @@ class GammaHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, 1))
 
             _emission_concentrations = jnp.ones((self.num_states,))

--- a/dynamax/hidden_markov_model/models/gamma_hmm.py
+++ b/dynamax/hidden_markov_model/models/gamma_hmm.py
@@ -40,8 +40,7 @@ class GammaHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, 1))
 
             _emission_concentrations = jnp.ones((self.num_states,))

--- a/dynamax/hidden_markov_model/models/gamma_hmm.py
+++ b/dynamax/hidden_markov_model/models/gamma_hmm.py
@@ -40,7 +40,8 @@ class GammaHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, 1))
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, 1))
 
             _emission_concentrations = jnp.ones((self.num_states,))
             _emission_rates = jnp.ravel(1.0 / km.cluster_centers_)

--- a/dynamax/hidden_markov_model/models/gamma_hmm.py
+++ b/dynamax/hidden_markov_model/models/gamma_hmm.py
@@ -41,7 +41,7 @@ class GammaHMMEmissions(HMMEmissions):
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, 1))
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, 1))
 
             _emission_concentrations = jnp.ones((self.num_states,))
             _emission_rates = jnp.ravel(1.0 / km.cluster_centers_)

--- a/dynamax/hidden_markov_model/models/gamma_hmm.py
+++ b/dynamax/hidden_markov_model/models/gamma_hmm.py
@@ -40,7 +40,7 @@ class GammaHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, 1))
 
             _emission_concentrations = jnp.ones((self.num_states,))

--- a/dynamax/hidden_markov_model/models/gaussian_hmm.py
+++ b/dynamax/hidden_markov_model/models/gaussian_hmm.py
@@ -72,7 +72,8 @@ class GaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
 
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim)[None, :, :], (self.num_states, 1, 1))
@@ -169,7 +170,8 @@ class DiagonalGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scale_diags = jnp.ones((self.num_states, self.emission_dim))
 
@@ -289,7 +291,8 @@ class SphericalGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scales = jnp.ones((self.num_states,))
 
@@ -390,7 +393,8 @@ class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov = jnp.eye(self.emission_dim)
 
@@ -511,7 +515,8 @@ class LowRankGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov_diag_factors = jnp.ones((self.num_states, self.emission_dim))
             _emission_cov_low_rank_factors = jnp.zeros((self.num_states, self.emission_dim, self.emission_rank))

--- a/dynamax/hidden_markov_model/models/gaussian_hmm.py
+++ b/dynamax/hidden_markov_model/models/gaussian_hmm.py
@@ -72,8 +72,7 @@ class GaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
 
             _emission_means = jnp.array(km.cluster_centers_)
@@ -171,8 +170,7 @@ class DiagonalGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scale_diags = jnp.ones((self.num_states, self.emission_dim))
@@ -293,8 +291,7 @@ class SphericalGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scales = jnp.ones((self.num_states,))
@@ -396,8 +393,7 @@ class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov = jnp.eye(self.emission_dim)
@@ -519,8 +515,7 @@ class LowRankGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov_diag_factors = jnp.ones((self.num_states, self.emission_dim))

--- a/dynamax/hidden_markov_model/models/gaussian_hmm.py
+++ b/dynamax/hidden_markov_model/models/gaussian_hmm.py
@@ -73,7 +73,7 @@ class GaussianHMMEmissions(HMMEmissions):
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, self.emission_dim))
 
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim)[None, :, :], (self.num_states, 1, 1))
@@ -171,7 +171,7 @@ class DiagonalGaussianHMMEmissions(HMMEmissions):
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scale_diags = jnp.ones((self.num_states, self.emission_dim))
 
@@ -292,7 +292,7 @@ class SphericalGaussianHMMEmissions(HMMEmissions):
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scales = jnp.ones((self.num_states,))
 
@@ -394,7 +394,7 @@ class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov = jnp.eye(self.emission_dim)
 
@@ -516,7 +516,7 @@ class LowRankGaussianHMMEmissions(HMMEmissions):
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov_diag_factors = jnp.ones((self.num_states, self.emission_dim))
             _emission_cov_low_rank_factors = jnp.zeros((self.num_states, self.emission_dim, self.emission_rank))

--- a/dynamax/hidden_markov_model/models/gaussian_hmm.py
+++ b/dynamax/hidden_markov_model/models/gaussian_hmm.py
@@ -72,7 +72,8 @@ class GaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
 
             _emission_means = jnp.array(km.cluster_centers_)
@@ -170,7 +171,8 @@ class DiagonalGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scale_diags = jnp.ones((self.num_states, self.emission_dim))
@@ -291,7 +293,8 @@ class SphericalGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scales = jnp.ones((self.num_states,))
@@ -393,7 +396,8 @@ class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov = jnp.eye(self.emission_dim)
@@ -515,7 +519,8 @@ class LowRankGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov_diag_factors = jnp.ones((self.num_states, self.emission_dim))

--- a/dynamax/hidden_markov_model/models/gaussian_hmm.py
+++ b/dynamax/hidden_markov_model/models/gaussian_hmm.py
@@ -71,7 +71,8 @@ class GaussianHMMEmissions(HMMEmissions):
         if method.lower() == "kmeans":
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
-            km = KMeans(self.num_states).fit(emissions.reshape(-1, self.emission_dim))
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
 
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim)[None, :, :], (self.num_states, 1, 1))
@@ -167,7 +168,8 @@ class DiagonalGaussianHMMEmissions(HMMEmissions):
         if method.lower() == "kmeans":
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
-            km = KMeans(self.num_states).fit(emissions.reshape(-1, self.emission_dim))
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scale_diags = jnp.ones((self.num_states, self.emission_dim))
 
@@ -286,7 +288,8 @@ class SphericalGaussianHMMEmissions(HMMEmissions):
         if method.lower() == "kmeans":
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
-            km = KMeans(self.num_states).fit(emissions.reshape(-1, self.emission_dim))
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scales = jnp.ones((self.num_states,))
 
@@ -386,7 +389,8 @@ class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
         if method.lower() == "kmeans":
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
-            km = KMeans(self.num_states).fit(emissions.reshape(-1, self.emission_dim))
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov = jnp.eye(self.emission_dim)
 
@@ -506,7 +510,8 @@ class LowRankGaussianHMMEmissions(HMMEmissions):
         if method.lower() == "kmeans":
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
-            km = KMeans(self.num_states).fit(emissions.reshape(-1, self.emission_dim))
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov_diag_factors = jnp.ones((self.num_states, self.emission_dim))
             _emission_cov_low_rank_factors = jnp.zeros((self.num_states, self.emission_dim, self.emission_rank))

--- a/dynamax/hidden_markov_model/models/gaussian_hmm.py
+++ b/dynamax/hidden_markov_model/models/gaussian_hmm.py
@@ -72,7 +72,7 @@ class GaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
 
             _emission_means = jnp.array(km.cluster_centers_)
@@ -170,7 +170,7 @@ class DiagonalGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scale_diags = jnp.ones((self.num_states, self.emission_dim))
@@ -291,7 +291,7 @@ class SphericalGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_scales = jnp.ones((self.num_states,))
@@ -393,7 +393,7 @@ class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov = jnp.eye(self.emission_dim)
@@ -515,7 +515,7 @@ class LowRankGaussianHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_means = jnp.array(km.cluster_centers_)
             _emission_cov_diag_factors = jnp.ones((self.num_states, self.emission_dim))

--- a/dynamax/hidden_markov_model/models/gmm_hmm.py
+++ b/dynamax/hidden_markov_model/models/gmm_hmm.py
@@ -79,7 +79,7 @@ class GaussianMixtureHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))
@@ -301,7 +301,7 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))

--- a/dynamax/hidden_markov_model/models/gmm_hmm.py
+++ b/dynamax/hidden_markov_model/models/gmm_hmm.py
@@ -79,7 +79,8 @@ class GaussianMixtureHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))
@@ -301,7 +302,8 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))

--- a/dynamax/hidden_markov_model/models/gmm_hmm.py
+++ b/dynamax/hidden_markov_model/models/gmm_hmm.py
@@ -78,7 +78,8 @@ class GaussianMixtureHMMEmissions(HMMEmissions):
         if method.lower() == "kmeans":
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
-            km = KMeans(self.num_states).fit(emissions.reshape(-1, self.emission_dim))
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim), (self.num_states, self.num_components, 1, 1))
@@ -298,7 +299,8 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
         if method.lower() == "kmeans":
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
-            km = KMeans(self.num_states).fit(emissions.reshape(-1, self.emission_dim))
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))
             _emission_scale_diags = jnp.ones((self.num_states, self.num_components, self.emission_dim))

--- a/dynamax/hidden_markov_model/models/gmm_hmm.py
+++ b/dynamax/hidden_markov_model/models/gmm_hmm.py
@@ -79,8 +79,7 @@ class GaussianMixtureHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))
@@ -302,8 +301,7 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))

--- a/dynamax/hidden_markov_model/models/gmm_hmm.py
+++ b/dynamax/hidden_markov_model/models/gmm_hmm.py
@@ -80,7 +80,7 @@ class GaussianMixtureHMMEmissions(HMMEmissions):
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim), (self.num_states, self.num_components, 1, 1))
@@ -302,7 +302,7 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))
             _emission_scale_diags = jnp.ones((self.num_states, self.num_components, self.emission_dim))

--- a/dynamax/hidden_markov_model/models/gmm_hmm.py
+++ b/dynamax/hidden_markov_model/models/gmm_hmm.py
@@ -79,7 +79,8 @@ class GaussianMixtureHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim), (self.num_states, self.num_components, 1, 1))
@@ -300,7 +301,8 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.ones((self.num_states, self.num_components)) / self.num_components
             _emission_means = jnp.tile(jnp.array(km.cluster_centers_)[:, None, :], (1, self.num_components, 1))
             _emission_scale_diags = jnp.ones((self.num_states, self.num_components, self.emission_dim))

--- a/dynamax/hidden_markov_model/models/linreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/linreg_hmm.py
@@ -60,7 +60,8 @@ class LinearRegressionHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.input_dim))
             _emission_biases = jnp.array(km.cluster_centers_)
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim)[None, :, :], (self.num_states, 1, 1))

--- a/dynamax/hidden_markov_model/models/linreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/linreg_hmm.py
@@ -61,7 +61,7 @@ class LinearRegressionHMMEmissions(HMMEmissions):
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.input_dim))
             _emission_biases = jnp.array(km.cluster_centers_)
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim)[None, :, :], (self.num_states, 1, 1))

--- a/dynamax/hidden_markov_model/models/linreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/linreg_hmm.py
@@ -60,8 +60,7 @@ class LinearRegressionHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.input_dim))
             _emission_biases = jnp.array(km.cluster_centers_)

--- a/dynamax/hidden_markov_model/models/linreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/linreg_hmm.py
@@ -59,7 +59,8 @@ class LinearRegressionHMMEmissions(HMMEmissions):
         if method.lower() == "kmeans":
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
-            km = KMeans(self.num_states).fit(emissions.reshape(-1, self.emission_dim))
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.input_dim))
             _emission_biases = jnp.array(km.cluster_centers_)
             _emission_covs = jnp.tile(jnp.eye(self.emission_dim)[None, :, :], (self.num_states, 1, 1))

--- a/dynamax/hidden_markov_model/models/linreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/linreg_hmm.py
@@ -60,7 +60,8 @@ class LinearRegressionHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.input_dim))
             _emission_biases = jnp.array(km.cluster_centers_)

--- a/dynamax/hidden_markov_model/models/linreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/linreg_hmm.py
@@ -60,7 +60,7 @@ class LinearRegressionHMMEmissions(HMMEmissions):
             assert emissions is not None, "Need emissions to initialize the model with K-Means!"
             from sklearn.cluster import KMeans
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(emissions.reshape(-1, self.emission_dim))
             _emission_weights = jnp.zeros((self.num_states, self.emission_dim, self.input_dim))
             _emission_biases = jnp.array(km.cluster_centers_)

--- a/dynamax/hidden_markov_model/models/logreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/logreg_hmm.py
@@ -53,7 +53,8 @@ class LogisticRegressionHMMEmissions(HMMEmissions):
             flat_emissions = emissions.reshape(-1,)
             flat_inputs = inputs.reshape(-1, self.input_dim)
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0,
+                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(flat_inputs)
             _emission_weights = jnp.zeros((self.num_states, self.input_dim))
             _emission_biases = jnp.array([tfb.Sigmoid().inverse(flat_emissions[km.labels_ == k].mean())

--- a/dynamax/hidden_markov_model/models/logreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/logreg_hmm.py
@@ -52,7 +52,8 @@ class LogisticRegressionHMMEmissions(HMMEmissions):
 
             flat_emissions = emissions.reshape(-1,)
             flat_inputs = inputs.reshape(-1, self.input_dim)
-            km = KMeans(self.num_states).fit(flat_inputs)
+            key, subkey = jr.split(key)  # Create a random seed for SKLearn.
+            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(flat_inputs)
             _emission_weights = jnp.zeros((self.num_states, self.input_dim))
             _emission_biases = jnp.array([tfb.Sigmoid().inverse(flat_emissions[km.labels_ == k].mean())
                                           for k in range(self.num_states)])

--- a/dynamax/hidden_markov_model/models/logreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/logreg_hmm.py
@@ -53,7 +53,8 @@ class LogisticRegressionHMMEmissions(HMMEmissions):
             flat_emissions = emissions.reshape(-1,)
             flat_inputs = inputs.reshape(-1, self.input_dim)
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            km = KMeans(self.num_states, random_state=jnp.prod(subkey)).fit(flat_inputs)
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            km = KMeans(self.num_states, random_state=sklearn_key).fit(flat_inputs)
             _emission_weights = jnp.zeros((self.num_states, self.input_dim))
             _emission_biases = jnp.array([tfb.Sigmoid().inverse(flat_emissions[km.labels_ == k].mean())
                                           for k in range(self.num_states)])

--- a/dynamax/hidden_markov_model/models/logreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/logreg_hmm.py
@@ -53,7 +53,7 @@ class LogisticRegressionHMMEmissions(HMMEmissions):
             flat_emissions = emissions.reshape(-1,)
             flat_inputs = inputs.reshape(-1, self.input_dim)
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=4294967295)  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=min(jnp.iinfo(jnp.int32).max, 4294967295))  # The lims are set by SKLearn.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(flat_inputs)
             _emission_weights = jnp.zeros((self.num_states, self.input_dim))
             _emission_biases = jnp.array([tfb.Sigmoid().inverse(flat_emissions[km.labels_ == k].mean())

--- a/dynamax/hidden_markov_model/models/logreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/logreg_hmm.py
@@ -53,8 +53,7 @@ class LogisticRegressionHMMEmissions(HMMEmissions):
             flat_emissions = emissions.reshape(-1,)
             flat_inputs = inputs.reshape(-1, self.input_dim)
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
-            sklearn_key = jr.randint(subkey, shape=(), minval=0,
-                                     maxval=min(int(jnp.iinfo(jnp.int32).max), 4294967295))  # The lims are set by SKLearn.
+            sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
             km = KMeans(self.num_states, random_state=sklearn_key).fit(flat_inputs)
             _emission_weights = jnp.zeros((self.num_states, self.input_dim))
             _emission_biases = jnp.array([tfb.Sigmoid().inverse(flat_emissions[km.labels_ == k].mean())

--- a/dynamax/hidden_markov_model/models/logreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/logreg_hmm.py
@@ -54,7 +54,7 @@ class LogisticRegressionHMMEmissions(HMMEmissions):
             flat_inputs = inputs.reshape(-1, self.input_dim)
             key, subkey = jr.split(key)  # Create a random seed for SKLearn.
             sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
-            km = KMeans(self.num_states, random_state=sklearn_key).fit(flat_inputs)
+            km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(flat_inputs)
             _emission_weights = jnp.zeros((self.num_states, self.input_dim))
             _emission_biases = jnp.array([tfb.Sigmoid().inverse(flat_emissions[km.labels_ == k].mean())
                                           for k in range(self.num_states)])


### PR DESCRIPTION
The KMeans initialisation used in many models uses the SKLearn implementation.  The SKLearn call is not seeded, breaking the determinism of the JAX code.  I assume at some point you are going to include a JAX implementation of KMeans, but until then, a simple fix is:
```
key, subkey = jr.split(key)  # Create a random seed for SKLearn.
sklearn_key = jr.randint(subkey, shape=(), minval=0, maxval=2147483647)  # Max int32 value.
km = KMeans(self.num_states, random_state=int(sklearn_key)).fit(emissions.reshape(-1, self.emission_dim))
```

The original flaw and solution are demonstrated in [this notebook](https://colab.research.google.com/drive/1G68iCObtt6rV0Eh-BlgSSMc0c-gdE3ed?usp=sharing).

Thanks,
A

