### PR TITLE
Parallel hmm posterior sample

### DIFF
--- a/dynamax/hidden_markov_model/__init__.py
+++ b/dynamax/hidden_markov_model/__init__.py
@@ -24,3 +24,4 @@ from dynamax.hidden_markov_model.inference import compute_transition_probs
 
 from dynamax.hidden_markov_model.parallel_inference import hmm_filter as parallel_hmm_filter
 from dynamax.hidden_markov_model.parallel_inference import hmm_smoother as parallel_hmm_smoother
+from dynamax.hidden_markov_model.parallel_inference import hmm_posterior_sample as parallel_hmm_posterior_sample

--- a/dynamax/hidden_markov_model/parallel_inference.py
+++ b/dynamax/hidden_markov_model/parallel_inference.py
@@ -1,11 +1,23 @@
 import jax.numpy as jnp
+import jax.random as jr
 from jax import lax, vmap, value_and_grad
-from jaxtyping import Array, Float
+from jaxtyping import Array, Float, Int
 from typing import NamedTuple, Union
+from functools import partial
 
 from dynamax.hidden_markov_model.inference import HMMPosterior, HMMPosteriorFiltered
 
-class Message(NamedTuple):
+#---------------------------------------------------------------------------#
+#                                Filtering                                  #
+#---------------------------------------------------------------------------#
+
+class FilterMessage(NamedTuple):
+    """Filtering associative scan elements.
+
+    Attributes:
+        A: $p(z_j \mid z_i)$
+        log_b: $\log P(y_{i+1}, ..., y_j \mid z_i)$
+    """    
     A: Float[Array, "num_timesteps num_states num_states"]
     log_b: Float[Array, "num_timesteps num_states"]
 
@@ -43,7 +55,7 @@ def hmm_filter(initial_probs: Float[Array, "num_states"],
         A_ij_cond, lognorm = _condition_on(m_ij.A, m_jk.log_b)
         A_ik = A_ij_cond @ m_jk.A
         log_b_ik = m_ij.log_b + lognorm
-        return Message(A=A_ik, log_b=log_b_ik)
+        return FilterMessage(A=A_ik, log_b=log_b_ik)
 
 
     # Initialize the messages
@@ -51,7 +63,7 @@ def hmm_filter(initial_probs: Float[Array, "num_states"],
     A0 *= jnp.ones((K, K))
     log_b0 *= jnp.ones(K)
     A1T, log_b1T = vmap(_condition_on, in_axes=(None, 0))(transition_matrix, log_likelihoods[1:])
-    initial_messages = Message(
+    initial_messages = FilterMessage(
         A=jnp.concatenate([A0[None, :, :], A1T]),
         log_b=jnp.vstack([log_b0, log_b1T])
     )
@@ -70,6 +82,11 @@ def hmm_filter(initial_probs: Float[Array, "num_states"],
     return HMMPosteriorFiltered(marginal_loglik=marginal_loglik,
                                 filtered_probs=filtered_probs,
                                 predicted_probs=predicted_probs)
+
+
+#---------------------------------------------------------------------------#
+#                                 Smoothing                                 #
+#---------------------------------------------------------------------------#
 
 
 def hmm_smoother(initial_probs: Float[Array, "num_states"],
@@ -110,3 +127,68 @@ def hmm_smoother(initial_probs: Float[Array, "num_states"],
         smoothed_probs=smoothed_probs,
         trans_probs=trans_probs
     )
+
+
+#---------------------------------------------------------------------------#
+#                                  Sampling                                 #
+#---------------------------------------------------------------------------#
+"""Associative scan elements $E_ij$ are vectors specifying a sample::
+
+    $z_j ~ p(z_j \mid z_i)$ 
+    
+for each possible value of $z_i$.
+"""
+
+def _initialize_sampling_messages(rng, transition_matrix, filtered_probs):
+    """Preprocess filtering output to construct input for sampling assocative scan."""
+
+    T, K = filtered_probs.shape
+    rngs = jr.split(rng, T)
+
+    def _last_message(rng, probs):
+        state = jr.choice(rng, K, p=probs)
+        return jnp.repeat(state, K)
+
+    @vmap
+    def _generic_message(rng, probs):
+        smoothed_probs = probs * transition_matrix.T
+        smoothed_probs = smoothed_probs / smoothed_probs.sum(1).reshape(K,1)
+        return vmap(lambda p: jr.choice(rng, K, p=p))(smoothed_probs)
+
+    En = _last_message(rngs[-1], filtered_probs[-1])
+    Et = _generic_message(rngs[:-1], filtered_probs[:-1])
+    return jnp.concatenate([Et, En[None]])
+
+
+def hmm_posterior_sample(rng: jr.PRNGKey,
+                         initial_distribution: Float[Array, "num_states"],
+                         transition_matrix: Float[Array, "num_states num_states"],
+                         log_likelihoods: Float[Array, "num_timesteps num_states"]
+) -> Int[Array, "num_timesteps"]:
+    r"""Sample a sequence of hidden states from the posterior.
+
+    Args:
+        rng: random number generator
+        initial_distribution: $p(z_1 \mid u_1, \theta)$
+        transition_matrix: $p(z_{t+1} \mid z_t, u_t, \theta)$
+        log_likelihoods: $p(y_t \mid z_t, u_t, \theta)$ for $t=1,\ldots, T$.
+ 
+    Returns:
+        log_normalizer: $\log P(y_{1:T} \mid u_{1:T}, \theta)$
+        states: sequence of hidden states $z_{1:T}$
+    """
+    T, K = log_likelihoods.shape
+
+    # Run the HMM filter
+    post = hmm_filter(initial_distribution, transition_matrix, log_likelihoods)
+    log_normalizer = post.marginal_loglik
+    filtered_probs = post.filtered_probs
+
+    @vmap
+    def _operator(E_jk, E_ij):
+        return jnp.take(E_ij, E_jk)
+
+    initial_messages = _initialize_sampling_messages(rng, transition_matrix, filtered_probs)
+    final_messages = lax.associative_scan(_operator, initial_messages, reverse=True)
+    states = final_messages[:,0]
+    return log_normalizer, states


### PR DESCRIPTION
This PR implements a parallel version of HMM posterior sampling using associative scan (see https://github.com/probml/dynamax/issues/341). The scan elements $E_{ij}$ are vectors specifying a sample

    z_j ~ p(z_j \mid z_i)
    
for each possible value of $z_i$. They can be thought of as functions $E : [1,...,n] \to [1,...,n]$ where the associative operator is function composition. This implementation passes the test written for serial sampling (which is commented out for some reason). It starts performing better than serial sampling when the sequence length exceeds a few thousand (I'm a little mystified as to why it takes so long for the crossover to happen).

```python
from dynamax.hidden_markov_model.inference_test import random_hmm_args
from dynamax.hidden_markov_model import hmm_posterior_sample, parallel_hmm_posterior_sample
import matplotlib.pyplot as plt
import jax.numpy as jnp
import jax.random as jr
import numpy as np
import time

num_states = 2
num_iters = 5
timesteps = np.logspace(0,6,10).astype(int)
serial_times, parallel_times = [], []
for num_timesteps in timesteps:
    print(num_timesteps)
    serial_time, parallel_time = 0, 0
    for itr in range(num_iters+1):
        args = random_hmm_args(jr.PRNGKey(itr), num_timesteps, 5)
        
        t = time.time()
        hmm_posterior_sample(jr.PRNGKey(itr), *args)
        print('s', time.time()-t)
        if itr > 0: serial_time += time.time()-t
            
        t = time.time()
        parallel_hmm_posterior_sample(jr.PRNGKey(itr), *args)
        print('p', time.time()-t)
        if itr > 0: parallel_time += time.time()-t
            
    serial_times.append(serial_time/num_iters)
    parallel_times.append(parallel_time/num_iters)
    
plt.plot(timesteps, serial_times, label='serial')
plt.plot(timesteps, parallel_times, label='parallel')
plt.legend(loc='upper left')
plt.xscale('log')
plt.yscale('log')
plt.ylabel('Runtime (s)')
plt.xlabel('Sequence length')
plt.gcf().set_size_inches((3,2))
```

<img width="343" alt="Screenshot 2023-09-05 at 11 22 51 AM" src="https://github.com/probml/dynamax/assets/6147762/4aa3d6b7-eaff-4d8c-ad77-4d1f57207a1b">
