### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/notebooks/linear_gaussian_ssm/kf_linreg.ipynb
+++ b/docs/notebooks/linear_gaussian_ssm/kf_linreg.ipynb
@@ -140,7 +140,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Offline inferenece\n",
+    "## Offline inference\n",
     "\n",
     "We compute the offline posterior given all the data using Bayes rule for linear regression.\n",
     "This should give the same results as the final step of online inference."


### PR DESCRIPTION
This PR fixes a typo in the documentation in `kf_linreg`