### PR TITLE
Use reverse=True keyword argument in lax.scan for smoothers

### DIFF
--- a/dynamax/nonlinear_gaussian_ssm/sarkka_lib.py
+++ b/dynamax/nonlinear_gaussian_ssm/sarkka_lib.py
@@ -63,9 +63,9 @@ def eks(m_0, P_0, f, Q, h, R, Y):
         return (m_sm, P_sm), (m_sm, P_sm)
 
     carry = (m_post[-1], P_post[-1])
-    _, (m_sm, P_sm) = lax.scan(_step, carry, jnp.arange(num_timesteps - 2, -1, -1))
-    m_sm = jnp.concatenate((jnp.array([m_post[-1]]), m_sm))[::-1]
-    P_sm = jnp.concatenate((jnp.array([P_post[-1]]), P_sm))[::-1]
+    _, (m_sm, P_sm) = lax.scan(_step, carry, jnp.arange(num_timesteps - 1), reverse=True)
+    m_sm = jnp.concatenate((jnp.array([m_post[-1]]), m_sm))
+    P_sm = jnp.concatenate((jnp.array([P_post[-1]]), P_sm))
 
     return m_sm, P_sm
 
@@ -196,8 +196,8 @@ def uks(m_0, P_0, f, Q, h, R, alpha, beta, kappa, Y):
         return jnp.concatenate((jnp.array([m]), sigma_plus, sigma_minus))
 
     carry = (m_post[-1], P_post[-1])
-    _, (m_sm, P_sm) = lax.scan(_step, carry, jnp.arange(num_timesteps - 2, -1, -1))
-    m_sm = jnp.concatenate((jnp.array([m_post[-1]]), m_sm))[::-1]
-    P_sm = jnp.concatenate((jnp.array([P_post[-1]]), P_sm))[::-1]
+    _, (m_sm, P_sm) = lax.scan(_step, carry, jnp.arange(num_timesteps - 1), reverse=True)
+    m_sm = jnp.concatenate((jnp.array([m_post[-1]]), m_sm))
+    P_sm = jnp.concatenate((jnp.array([P_post[-1]]), P_sm))
 
     return m_sm, P_sm

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     scikit-learn
     jaxtyping
     typing-extensions
+    numpy<2.0
 
 packages = find:
 


### PR DESCRIPTION
Fixes issue https://github.com/probml/dynamax/issues/364 by using the `reverse=True` keyword argument in `lax.scan` function.

Tests are passing locally except for the unscented kalman filter inference tests, but these were also failing for the original code as far as I can tell?

I also had to pin `numpy < 2.0` because `tensorflow_probability` was failing (note that this is also a problem in the [docs](https://probml.github.io/dynamax/notebooks/hmm/gaussian_hmm.html).

There could potentially be further improvement in eliminating unnecessary memory copies by array slicing but I think it would destroy some of the readability of the code and result in some computation overhead. For example, the stack operations (`jnp.vstack([smoothed_probs, filtered_probs[-1]])` and  slicing `filtered_probs[:-1]`) create copies. This isn't really a problem unless you have a large number of states:

```python
    # Run the HMM smoother
    _, smoothed_probs = lax.scan(
        _step,
        filtered_probs[-1],
        (jnp.arange(num_timesteps - 1), filtered_probs[:-1], predicted_probs[1:]),
        reverse=True,
    )

    # Concatenate the arrays and return
    smoothed_probs = jnp.vstack([smoothed_probs, filtered_probs[-1]])
```
