### PR TITLE
Correct typo

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -25,7 +25,7 @@ authors:
     affiliation: "7"
     corresponding: true
 affiliations:
- - name: Department of Statistics and Wu Tsai Neurosciences Insitute, Stanford University, USA
+ - name: Department of Statistics and Wu Tsai Neurosciences Institute, Stanford University, USA
    index: 1
  - name: CSAIL, Massachusetts Institute of Technology, USA
    index: 2


### PR DESCRIPTION
This PR corrects a typo in the affiliation field.

This is as part of the repo's JOSS review: https://github.com/openjournals/joss-reviews/issues/7069