### PR TITLE
Add testing workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,15 +11,21 @@ on:
 
 jobs:
   Workflow:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Select the Python versions to test against
+        os: ["ubuntu-latest", "macos-latest"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+    name: ${{ matrix.os }} with Python ${{ matrix.python-version }}
     steps:
     - name: Clone the reference repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.5.2
 
-    - name: Set up Python 3.10.6
-      uses: actions/setup-python@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.10.6'
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This PR alters the testing workflow to consider all supported Python versions. Additionally, tests are executed on a Linux and Mac machine.

As part of my larger review, I suggest increasing the lower bound on supported Python versions. Should this suggested be adopted, then the workflow should be altered to reflect the bump.

This PR is part of my JOSS review: https://github.com/openjournals/joss-reviews/issues/7069