### PR TITLE
Prevent jupyter notebooks from being listed in used languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 dynamax/_version.py export-subst
+*.ipynb linguist-documentation


### PR DESCRIPTION
Currently, `dynamax` is listed as being written in the `jupyter notebook` programming language. This PR proposes to exclude jupyter notebooks from being considered. Therefore, `dynamax` will be listed a a `Python` package. See also, e.g., [this stackoverflow post](https://stackoverflow.com/questions/19052834/is-it-possible-to-exclude-files-from-git-language-statistics).