### PR TITLE
Add __repr__ method to ParameterProperties

### DIFF
--- a/dynamax/parameters.py
+++ b/dynamax/parameters.py
@@ -46,6 +46,9 @@ class ParameterProperties:
     def tree_unflatten(cls, aux_data, children):
         return cls(*aux_data)
 
+    def __repr__(self):
+        return f"ParameterProperties(trainable={self.trainable}, constrainer={self.constrainer})"
+
 
 def to_unconstrained(params: ParameterSet, props: PropertySet) -> ParameterSet:
     """Convert the constrained parameters to unconstrained form.


### PR DESCRIPTION
# Summary 

Adds a `__repr__` method to the `ParameterProperties` class that returns a string representation of the object. 

This is a QOL improvement for interacting with `ParameterProperties` objects in an interactive environment.
