### PR TITLE
Add coverage to test workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -e '.[dev]'
+        pip install -e '.[test]'
 
     - name: Run tests
-      run: pytest
+      run: pytest --cov=./


### PR DESCRIPTION
## Summary 

Add the coverage report to the GH action - report will be printed in the GH action.

Additionally install the `test` dependencies rather than the `dev` dependencies - this should test that our `test` dependencies are sufficient to run the tests.
