### PR TITLE
Fixes #400

### DIFF
--- a/dynamax/linear_gaussian_ssm/models.py
+++ b/dynamax/linear_gaussian_ssm/models.py
@@ -7,12 +7,12 @@ import tensorflow_probability.substrates.jax.distributions as tfd
 
 from fastprogress.fastprogress import progress_bar
 from functools import partial
-from jax import jit
+from jax import jit, tree, vmap
 from jax.tree_util import tree_map
 from jaxtyping import Array, Float
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN
 from typing import Any, Optional, Tuple, Union, runtime_checkable
-from typing_extensions import Protocol 
+from typing_extensions import Protocol
 
 from dynamax.ssm import SSM
 from dynamax.linear_gaussian_ssm.inference import lgssm_joint_sample, lgssm_filter, lgssm_smoother, lgssm_posterior_sample
@@ -24,7 +24,7 @@ from dynamax.utils.bijectors import RealToPSDBijector
 from dynamax.utils.distributions import MatrixNormalInverseWishart as MNIW
 from dynamax.utils.distributions import NormalInverseWishart as NIW
 from dynamax.utils.distributions import mniw_posterior_update, niw_posterior_update
-from dynamax.utils.utils import pytree_stack, psd_solve
+from dynamax.utils.utils import ensure_array_has_batch_dim, pytree_stack, psd_solve
 
 @runtime_checkable
 class SuffStatsLGSSM(Protocol):
@@ -206,7 +206,7 @@ class LinearGaussianSSM(SSM):
                key: PRNGKeyT,
                num_timesteps: int,
                inputs: Optional[Float[Array, "num_timesteps input_dim"]] = None) \
-                -> Tuple[Float[Array, "num_timesteps state_dim"], 
+                -> Tuple[Float[Array, "num_timesteps state_dim"],
                          Float[Array, "num_timesteps emission_dim"]]:
         """Sample from the model.
         
@@ -607,18 +607,20 @@ class LinearGaussianConjugateSSM(LinearGaussianSSM):
         Returns:
             parameter object, where each field has `sample_size` copies as leading batch dimension.
         """
-        num_timesteps = len(emissions)
+        batch_emissions = ensure_array_has_batch_dim(emissions, self.emission_shape)
+        batch_inputs = ensure_array_has_batch_dim(inputs, self.inputs_shape)
 
-        if inputs is None:
-            inputs = jnp.zeros((num_timesteps, 0))
+        num_batches, num_timesteps = batch_emissions.shape[:2]
 
-        def sufficient_stats_from_sample(states):
+        if batch_inputs is None:
+            batch_inputs = jnp.zeros((num_batches, num_timesteps, 0))
+
+        def sufficient_stats_from_sample(y, inputs, states):
             """Convert samples of states to sufficient statistics."""
             inputs_joint = jnp.concatenate((inputs, jnp.ones((num_timesteps, 1))), axis=1)
             # Let xn[t] = x[t+1]          for t = 0...T-2
             x, xp, xn = states, states[:-1], states[1:]
             u, up = inputs_joint, inputs_joint[:-1]
-            y = emissions
 
             init_stats = (x[0], jnp.outer(x[0], x[0]), 1)
 
@@ -678,9 +680,13 @@ class LinearGaussianConjugateSSM(LinearGaussianSSM):
             """Sample a single set of states and compute their sufficient stats."""
             rngs = jr.split(rng, 2)
             # Sample latent states
-            states = lgssm_posterior_sample(rngs[0], _params, emissions, inputs)
+            batch_keys = jr.split(rngs[0], num=num_batches)
+            forward_backward_batched = vmap(partial(lgssm_posterior_sample, params=_params))
+            batch_states = forward_backward_batched(batch_keys, emissions=batch_emissions, inputs=batch_inputs)
+            _batch_stats = vmap(sufficient_stats_from_sample)(batch_emissions, batch_inputs, batch_states)
+            # Aggregate statistics from all observations.
+            _stats = tree.map(lambda x: jnp.sum(x, axis=0), _batch_stats)
             # Sample parameters
-            _stats = sufficient_stats_from_sample(states)
             return lgssm_params_sample(rngs[1], _stats)
 
 


### PR DESCRIPTION
The current implementation of `LinearGaussianConjugateSSM.fit_blocked_gibbs` misses the part that takes care of the batching of `emissions` and `inputs` over the leading axis (issue #400 ). This pull request corrects `fit_blocked_gibbs` to support the "nbatch" dimension by:
- `vmap`ing over the forward filtering backwards sampling
- map-reducing the sufficient statistics

This pull request is accompanied by a minimal unit test that tests batching.