### PR TITLE
Bugfix InverseWishart scale matrix

### DIFF
--- a/dynamax/utils/distributions.py
+++ b/dynamax/utils/distributions.py
@@ -42,8 +42,8 @@ class InverseWishart(tfd.TransformedDistribution):
         # Wishart distribution
         dim = scale.shape[-1]
         eye = jnp.broadcast_to(jnp.eye(dim), scale.shape)
-        cho_scale = jnp.linalg.cholesky(scale)
-        inv_scale_tril = solve_triangular(cho_scale, eye, lower=True)
+        inv_scale = psd_solve(A=scale, b=eye)
+        inv_scale_tril = jnp.linalg.cholesky(inv_scale)
 
         super().__init__(
             tfd.WishartTriL(df, scale_tril=inv_scale_tril),


### PR DESCRIPTION
This PR aims to address the wrong samples generated by the `dynamax.utils.distributions.InverseWishart` (and by extension, those related to `NormalInverseWishart`, `MatrixNormalInverseWishart`, and `LinearGaussianConjugateSSM`). See issue #407.

**Diagnosis**
The inverse Wishart is related by the Wishart distribution as
$` X^{-1} \sim W(\nu, \psi) \leftrightarrow X \sim W^{-1}(\nu, \psi^{-1}) `$

The original implementation computed the inverse of the Cholesky decomposition $\psi = L L^T$, instead of the Cholesky decomposition of the inverse $\psi^{-1}$.

**Fix**
Swap the order of the operations.

I've adapted the code snippet in #407 to be used as accompanying unit test.