### PR TITLE
removing numpy<2.0 pin and ignoring coverage outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ docs/_build/
 build/
 dist/
 
+.coverage
+
 *egg-info
 *.ipynb_checkpoints
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "scikit-learn",
     "jaxtyping",
     "typing-extensions",
-    "numpy<2.0"
+    "numpy"
 ]
 
 authors = [


### PR DESCRIPTION
The bug in tensorflow probability (https://github.com/tensorflow/probability/issues/1814) seems to be resolved, so we can relax our numpy version pin finally!