### PR TITLE
fix typos in lgssm_learning.ipynb

### DIFF
--- a/docs/notebooks/linear_gaussian_ssm/lgssm_learning.ipynb
+++ b/docs/notebooks/linear_gaussian_ssm/lgssm_learning.ipynb
@@ -10,14 +10,14 @@
     "\n",
     "This notebook shows how to \"fit\" a linear Gaussian SSM &mdash; i.e., estimate the parameters and infer the latent states &mdash; using either expectation-maximization (EM) or stochastic gradient descent (SGD) on the negative log marginal likelihood of the data. \n",
     "\n",
-    "Here, we work with simulate noisy data from an LG-SSM with known parameters, and then we see how well we can recover the true parameters and states given the observations. The model is,\n",
+    "Here, we work with simulated noisy data from an LG-SSM with known parameters, and then we see how well we can recover the true parameters and states given the observations. The model is,\n",
     "\\begin{align*}\n",
-    "z_{t+1} \\mid z_t, \\theta &\\sim \\mathrm{N}(F z_t, Q) \\\\\n",
-    "y_t \\mid z_t, \\theta &\\sim \\mathrm{N}(H z_t, R)\n",
+    "z_{t+1} \\mid z_t, \\theta &\\sim \\mathcal{N}(F z_t, Q) \\\\\n",
+    "y_t \\mid z_t, \\theta &\\sim \\mathcal{N}(H z_t, R)\n",
     "\\end{align*}\n",
-    "where $z_{1:T}$ are the latent states, $y_{1:T}$ are the emissions, and $\\theta = (F, Q, H, R)$ are the model parameters. In particular, $F$ is the dynamics matrix and $H$ is the emission matrix. For our simulation, we use 2-dimensional latent states, $z_t \\in \\mathbb{R}^2$, and 10-dimensional emissions, $y_t \\in \\mathbb{R}^10$. \n",
+    "where $z_{1:T}$ are the latent states, $y_{1:T}$ are the emissions, and $\\theta = (F, Q, H, R)$ are the model parameters. In particular, $F$ is the dynamics matrix and $H$ is the emission matrix. For our simulation, we use 2-dimensional latent states, $z_t \\in \\mathbb{R}^2$, and 10-dimensional emissions, $y_t \\in \\mathbb{R}^{10}$. \n",
     "\n",
-    "We fit the model to estimate parameters, $\\hat{\\theta}$, using either EM or SGD, as shown below. Once we have estimated the paraemeters, we can also infer the latent states given those parameters.\n"
+    "We fit the model to estimate parameters, $\\hat{\\theta}$, using either EM or SGD, as shown below. Once we have estimated the parameters, we can also infer the latent states given those parameters.\n"
    ]
   },
   {
@@ -542,7 +542,7 @@
     "sgd_params, sgd_param_props = model.initialize(\n",
     "    init_key, dynamics_weights=true_A, dynamics_covariance=true_Sigma)\n",
     "\n",
-    "print(f\"freeing the dynamics matrix to:\\n {sgd_params.dynamics.weights}\")\n",
+    "print(f\"freezing the dynamics matrix to:\\n {sgd_params.dynamics.weights}\")\n",
     "sgd_param_props.dynamics.weights.trainable = False\n",
     "sgd_param_props.dynamics.cov.trainable = False\n",
     "\n",


### PR DESCRIPTION
"work with simulate noisy data" -> "work with simulate**d** noisy data"
$\mathrm{N}(F z_t, Q)$ -> $\mathcal{N}(F z_t, Q)$
$\mathrm{N}(H z_t, R)$ -> $\mathcal{N}(H z_t, R)$
$\mathbb{R}^10$ -> $\mathbb{R}^{10}$
"paraemeters" -> "parameters"
"freeing the dynamics matrix" -> "free**z**ing the dynamics matrix"