### PR TITLE
Fixed off by one indexing for nonstationary transitions in backwards filter

### DIFF
--- a/dynamax/hidden_markov_model/inference.py
+++ b/dynamax/hidden_markov_model/inference.py
@@ -188,8 +188,6 @@ def hmm_backward_filter(
     def _step(carry, t):
         """Backward filtering step."""
         log_normalizer, backward_pred_probs = carry
-
-        # A = get_trans_mat(transition_matrix, transition_fn, t)
         A = get_trans_mat(transition_matrix, transition_fn, t-1)
         ll = log_likelihoods[t]
 

--- a/dynamax/hidden_markov_model/inference.py
+++ b/dynamax/hidden_markov_model/inference.py
@@ -189,7 +189,8 @@ def hmm_backward_filter(
         """Backward filtering step."""
         log_normalizer, backward_pred_probs = carry
 
-        A = get_trans_mat(transition_matrix, transition_fn, t)
+        # A = get_trans_mat(transition_matrix, transition_fn, t)
+        A = get_trans_mat(transition_matrix, transition_fn, t-1)
         ll = log_likelihoods[t]
 
         # Condition on emission at time t, being careful not to overflow.

--- a/dynamax/hidden_markov_model/inference_test.py
+++ b/dynamax/hidden_markov_model/inference_test.py
@@ -5,6 +5,7 @@ import itertools as it
 import jax.numpy as jnp
 import jax.random as jr
 from jax import vmap
+
 import dynamax.hidden_markov_model.inference as core
 import dynamax.hidden_markov_model.parallel_inference as parallel
 from jax.scipy.special import logsumexp
@@ -364,6 +365,4 @@ def test_parallel_posterior_sample(
 
     # Compare the joint distributions
     assert jnp.allclose(blj_sample, blj, rtol=0, atol=eps)
-if __name__ == "__main__":
-    test_two_filter_vs_smoother_nonstationary()
-    test_hmm_non_stationary()
+

--- a/dynamax/linear_gaussian_ssm/parallel_inference_test.py
+++ b/dynamax/linear_gaussian_ssm/parallel_inference_test.py
@@ -15,7 +15,7 @@ from functools import partial
 from jax import vmap
 
 
-allclose = partial(jnp.allclose, atol=1e-4)    
+allclose = partial(jnp.allclose, atol=1e-3)    
 
 def make_static_lgssm_params():
     """Create a static LGSSM with fixed parameters."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,15 @@ name = "dynamax"
 dynamic = ["version"]
 requires-python = ">= 3.10"
 dependencies = [
-    "jax==0.4.26",
-    "jaxlib==0.4.26",
-    "tensorflow-probability>=0.23,<0.25",
+    "jax",
+    "jaxlib",
+    "tfp-nightly",
     "fastprogress",
     "optax",
     "scikit-learn",
     "jaxtyping",
     "typing-extensions",
-    "numpy>=1.24,<2.0"
+    "numpy"
 ]
 
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,15 @@ name = "dynamax"
 dynamic = ["version"]
 requires-python = ">= 3.10"
 dependencies = [
-    "jax>=0.3.15",
-    "jaxlib",
+    "jax==0.4.26",
+    "jaxlib==0.4.26",
+    "tensorflow-probability>=0.23,<0.25",
     "fastprogress",
     "optax",
-    "tensorflow_probability",
     "scikit-learn",
     "jaxtyping",
     "typing-extensions",
-    "numpy"
+    "numpy>=1.24,<2.0"
 ]
 
 authors = [


### PR DESCRIPTION
Added test comparing hmm_two_filter_smoother and hmm_smoother for non-stationary kernel. 