### PR TITLE
Off by one in input driven HMM

### DIFF
--- a/dynamax/hidden_markov_model/models/abstractions.py
+++ b/dynamax/hidden_markov_model/models/abstractions.py
@@ -295,7 +295,7 @@ class HMMTransitions(ABC):
             PyTree of sufficient statistics for updating the transition distribution
 
         """
-        return posterior.trans_probs, pytree_slice(inputs, slice(1, None))
+        return posterior.trans_probs, inputs 
 
     def initialize_m_step_state(self, params: ParameterSet, props:PropertySet) -> Any:
         """Initialize any required state for the M step.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ test = [
     "coverage",
     "pytest>=3.9",
     "pytest-cov",
-    "interrogate>=1.5.0"
+    "interrogate>=1.5.0",
+    "ipython"
 ]
 
 dev = [
@@ -91,7 +92,8 @@ dev = [
     "coverage",
     "pytest>=3.9",
     "pytest-cov",
-    "interrogate>=1.5.0"
+    "interrogate>=1.5.0",
+    "ipython"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Fixing error found by user [umeshksingla](https://github.com/umeshksingla/dynamax/commits?author=umeshksingla).

Previous code sliced inputs[1:] twice. So inputs[2:] was incorrectly passed for the m step (length T-2 rather than T-1). 