### PR TITLE
Fix Input Dim Bug For Generalized/Nonlinear Gaussian SSMs

### DIFF
--- a/dynamax/generalized_gaussian_ssm/models.py
+++ b/dynamax/generalized_gaussian_ssm/models.py
@@ -85,7 +85,7 @@ class GeneralizedGaussianSSM(SSM):
     def __init__(self, state_dim, emission_dim, input_dim=0):
         self.state_dim = state_dim
         self.emission_dim = emission_dim
-        self.input_dim = 0
+        self.input_dim = input_dim
 
     @property
     def emission_shape(self):

--- a/dynamax/nonlinear_gaussian_ssm/models.py
+++ b/dynamax/nonlinear_gaussian_ssm/models.py
@@ -70,7 +70,7 @@ class NonlinearGaussianSSM(SSM):
     def __init__(self, state_dim: int, emission_dim: int, input_dim: int = 0):
         self.state_dim = state_dim
         self.emission_dim = emission_dim
-        self.input_dim = 0
+        self.input_dim = input_dim
 
     @property
     def emission_shape(self):


### PR DESCRIPTION
In `GeneralizedGaussianSSM` and `NonlinearGaussianSSM`, there is an `input_dim` argument with default 0 which is ignored, with `self.input_dim` hardcoded to 0 instead. 