### PR TITLE
ci: add Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Set up automated updates with Dependabot for GitHub Actions used in CI/CD.
- https://github.com/probml/dynamax/pull/450 pinned actions to specific versions. This PR will ensure that those pins don’t become outdated, improving security and function.
- Choices I made:
    - Update frequency: once per month (reduce PR noise)
    - Cooldown period: 7 days (wait to see if version is stable and safe)
    - Updates grouped into a single PR (reduce PR noise)