### PR TITLE
Enforce consistent policy for parameter freezing

### DIFF
--- a/dynamax/hidden_markov_model/models/gaussian_hmm.py
+++ b/dynamax/hidden_markov_model/models/gaussian_hmm.py
@@ -8,7 +8,7 @@ import tensorflow_probability.substrates.jax.distributions as tfd
 from jaxtyping import Float, Array
 import optax
 
-from dynamax.parameters import ParameterProperties
+from dynamax.parameters import ParameterProperties, ensure_all_or_none_trainable
 from dynamax.hidden_markov_model.inference import HMMPosterior
 from dynamax.hidden_markov_model.models.abstractions import HMM, HMMEmissions, HMMParameterSet, HMMPropertySet
 from dynamax.hidden_markov_model.models.initial import StandardHMMInitialState, ParamsStandardHMMInitialState
@@ -152,7 +152,7 @@ class GaussianHMMEmissions(HMMEmissions):
             m_step_state: Any
         ) -> Tuple[ParamsGaussianHMMEmissions, Any]:
         """Perform the M-step of the EM algorithm."""
-        if props.covs.trainable and props.means.trainable:
+        if ensure_all_or_none_trainable(props):
             niw_prior = NormalInverseWishart(loc=self.emission_prior_mean,
                                             mean_concentration=self.emission_prior_conc,
                                             df=self.emission_prior_df,
@@ -167,12 +167,6 @@ class GaussianHMMEmissions(HMMEmissions):
             emission_stats = pytree_sum(batch_stats, axis=0)
             covs, means = vmap(_single_m_step)(emission_stats)
             params = params._replace(means=means, covs=covs)
-
-        elif props.covs.trainable and not props.means.trainable:
-            raise NotImplementedError("GaussianHMM.fit_em() does not yet support fixed means and trainable covariance")
-
-        elif not props.covs.trainable and props.means.trainable:
-            raise NotImplementedError("GaussianHMM.fit_em() does not yet support fixed covariance and trainable means")
 
         return params, m_step_state
 
@@ -292,21 +286,22 @@ class DiagonalGaussianHMMEmissions(HMMEmissions):
 
     def m_step(self, params, props, batch_stats, m_step_state):
         """Perform the M-step of the EM algorithm."""
-        nig_prior = NormalInverseGamma(loc=self.emission_prior_mean,
-                                       mean_concentration=self.emission_prior_mean_conc,
-                                       concentration=self.emission_prior_conc,
-                                       scale=self.emission_prior_scale)
+        if ensure_all_or_none_trainable(props):
+            nig_prior = NormalInverseGamma(loc=self.emission_prior_mean,
+                                           mean_concentration=self.emission_prior_mean_conc,
+                                           concentration=self.emission_prior_conc,
+                                           scale=self.emission_prior_scale)
 
-        def _single_m_step(stats):
-            """Perform the M-step for a single state."""
-            # Find the posterior parameters of the NIG distribution
-            posterior = nig_posterior_update(nig_prior, (stats['sum_x'], stats['sum_xsq'], stats['sum_w']))
-            return posterior.mode()
+            def _single_m_step(stats):
+                """Perform the M-step for a single state."""
+                # Find the posterior parameters of the NIG distribution
+                posterior = nig_posterior_update(nig_prior, (stats['sum_x'], stats['sum_xsq'], stats['sum_w']))
+                return posterior.mode()
 
-        emission_stats = pytree_sum(batch_stats, axis=0)
-        vars, means = vmap(_single_m_step)(emission_stats)
-        scale_diags = jnp.sqrt(vars)
-        params = params._replace(means=means, scale_diags=scale_diags)
+            emission_stats = pytree_sum(batch_stats, axis=0)
+            vars, means = vmap(_single_m_step)(emission_stats)
+            scale_diags = jnp.sqrt(vars)
+            params = params._replace(means=means, scale_diags=scale_diags)
         return params, m_step_state
 
 
@@ -582,19 +577,20 @@ class SharedCovarianceGaussianHMMEmissions(HMMEmissions):
             m_step_state: Any
         ) -> Tuple[ParamsSharedCovarianceGaussianHMMEmissions, Any]:
         """Perform the M-step of the EM algorithm."""
-        mu0 = self.emission_prior_mean
-        kappa0 = self.emission_prior_conc
-        Psi0 = self.emission_prior_scale
-        nu0 = self.emission_prior_df
+        if ensure_all_or_none_trainable(props):
+            mu0 = self.emission_prior_mean
+            kappa0 = self.emission_prior_conc
+            Psi0 = self.emission_prior_scale
+            nu0 = self.emission_prior_df
 
-        emission_stats = pytree_sum(batch_stats, axis=0)
-        sum_T = emission_stats['sum_T'] + nu0 + self.num_states + self.emission_dim + 1
-        sum_w = emission_stats['sum_w'] + kappa0
-        sum_x = emission_stats['sum_x'] + kappa0 * mu0
-        sum_xxT = emission_stats['sum_xxT'] + Psi0 + kappa0 * jnp.outer(mu0, mu0)
-        means = jnp.einsum('ki,k->ki', sum_x, 1/sum_w)
-        cov = (sum_xxT - jnp.einsum('ki,kj,k->ij', sum_x, sum_x, 1/sum_w)) / sum_T
-        params = params._replace(means=means, cov=cov)
+            emission_stats = pytree_sum(batch_stats, axis=0)
+            sum_T = emission_stats['sum_T'] + nu0 + self.num_states + self.emission_dim + 1
+            sum_w = emission_stats['sum_w'] + kappa0
+            sum_x = emission_stats['sum_x'] + kappa0 * mu0
+            sum_xxT = emission_stats['sum_xxT'] + Psi0 + kappa0 * jnp.outer(mu0, mu0)
+            means = jnp.einsum('ki,k->ki', sum_x, 1/sum_w)
+            cov = (sum_xxT - jnp.einsum('ki,kj,k->ij', sum_x, sum_x, 1/sum_w)) / sum_T
+            params = params._replace(means=means, cov=cov)
         return params, m_step_state
 
 

--- a/dynamax/hidden_markov_model/models/gmm_hmm.py
+++ b/dynamax/hidden_markov_model/models/gmm_hmm.py
@@ -9,7 +9,7 @@ import tensorflow_probability.substrates.jax.distributions as tfd
 from jax import vmap
 from jax.scipy.special import logsumexp
 from jaxtyping import Float, Array
-from dynamax.parameters import ParameterProperties
+from dynamax.parameters import ParameterProperties, ensure_all_or_none_trainable
 from dynamax.utils.distributions import NormalInverseGamma
 from dynamax.utils.distributions import NormalInverseWishart
 from dynamax.utils.distributions import nig_posterior_update
@@ -208,29 +208,26 @@ class GaussianMixtureHMMEmissions(HMMEmissions):
             m_step_state: Any
     ) -> Tuple[ParamsGaussianMixtureHMMEmissions, Any]:
         """Perform the M-step of the EM algorithm."""
-        assert props.weights.trainable, "GaussianMixtureHMM.fit_em() does not support fitting a subset of parameters"
-        assert props.means.trainable, "GaussianMixtureHMM.fit_em() does not support fitting a subset of parameters"
-        assert props.covs.trainable, "GaussianMixtureHMM.fit_em() does not support fitting a subset of parameters"
+        if ensure_all_or_none_trainable(props):
+            niw_prior = NormalInverseWishart(self.emission_prior_mean,
+                                             self.emission_prior_mean_concentration,
+                                             self.emission_prior_df,
+                                             self.emission_prior_scale)
 
-        niw_prior = NormalInverseWishart(self.emission_prior_mean,
-                                         self.emission_prior_mean_concentration,
-                                         self.emission_prior_df,
-                                         self.emission_prior_scale)
+            def _single_m_step(Sx, SxxT, N):
+                """Update the parameters for one discrete state"""
+                # Update the component probabilities (i.e. weights)
+                nu_post = self.emission_weights_concentration + N
+                weights = tfd.Dirichlet(nu_post).mode()
 
-        def _single_m_step(Sx, SxxT, N):
-            """Update the parameters for one discrete state"""
-            # Update the component probabilities (i.e. weights)
-            nu_post = self.emission_weights_concentration + N
-            weights = tfd.Dirichlet(nu_post).mode()
+                # Update the mean and covariance for each component
+                covs, means = vmap(lambda stats: niw_posterior_update(niw_prior, stats).mode())((Sx, SxxT, N))
+                return weights, means, covs
 
-            # Update the mean and covariance for each component
-            covs, means = vmap(lambda stats: niw_posterior_update(niw_prior, stats).mode())((Sx, SxxT, N))
-            return weights, means, covs
-
-        emission_stats = pytree_sum(batch_stats, axis=0)
-        weights, means, covs = vmap(_single_m_step)(
-            emission_stats['Sx'], emission_stats['SxxT'], emission_stats['N'])
-        params = params._replace(weights=weights, means=means, covs=covs)
+            emission_stats = pytree_sum(batch_stats, axis=0)
+            weights, means, covs = vmap(_single_m_step)(
+                emission_stats['Sx'], emission_stats['SxxT'], emission_stats['N'])
+            params = params._replace(weights=weights, means=means, covs=covs)
         return params, m_step_state
 
 
@@ -491,32 +488,29 @@ class DiagonalGaussianMixtureHMMEmissions(HMMEmissions):
                m_step_state: None
     ) -> Tuple[ParamsDiagonalGaussianMixtureHMMEmissions, None]:
         """Perform the M-step of the EM algorithm."""
-        assert props.weights.trainable, "GaussianMixtureDiagHMM.fit_em() does not support fitting a subset of parameters"
-        assert props.means.trainable, "GaussianMixtureDiagHMM.fit_em() does not support fitting a subset of parameters"
-        assert props.scale_diags.trainable, "GaussianMixtureDiagHMM.fit_em() does not support fitting a subset of parameters"
+        if ensure_all_or_none_trainable(props):
+            nig_prior = NormalInverseGamma(
+                self.emission_prior_mean, self.emission_prior_mean_concentration,
+                self.emission_prior_shape, self.emission_prior_scale)
 
-        nig_prior = NormalInverseGamma(
-            self.emission_prior_mean, self.emission_prior_mean_concentration,
-            self.emission_prior_shape, self.emission_prior_scale)
+            def _single_m_step(Sx, Sxsq, N):
+                """Update the parameters for one discrete state"""
+                # Update the component probabilities (i.e. weights)
+                nu_post = self.emission_weights_concentration + N
+                mixture_weights = tfd.Dirichlet(nu_post).mode()
 
-        def _single_m_step(Sx, Sxsq, N):
-            """Update the parameters for one discrete state"""
-            # Update the component probabilities (i.e. weights)
-            nu_post = self.emission_weights_concentration + N
-            mixture_weights = tfd.Dirichlet(nu_post).mode()
+                # Update the mean and variances for each component
+                var_diags, means = vmap(lambda stats: nig_posterior_update(nig_prior, stats).mode())((Sx, Sxsq, N))
+                scale_diags = jnp.sqrt(var_diags)
+                return mixture_weights, means, scale_diags
 
-            # Update the mean and variances for each component
-            var_diags, means = vmap(lambda stats: nig_posterior_update(nig_prior, stats).mode())((Sx, Sxsq, N))
-            scale_diags = jnp.sqrt(var_diags)
-            return mixture_weights, means, scale_diags
-
-        # Compute mixture weights, diagonal factors of covariance matrices and means
-        # for each state in parallel. Note that the first dimension of all sufficient
-        # statistics is equal to number of states of HMM.
-        emission_stats = pytree_sum(batch_stats, axis=0)
-        weights, means, scale_diags = vmap(_single_m_step)(
-            emission_stats['Sx'], emission_stats['Sxsq'], emission_stats['N'])
-        params = params._replace(weights=weights, means=means, scale_diags=scale_diags)
+            # Compute mixture weights, diagonal factors of covariance matrices and means
+            # for each state in parallel. Note that the first dimension of all sufficient
+            # statistics is equal to number of states of HMM.
+            emission_stats = pytree_sum(batch_stats, axis=0)
+            weights, means, scale_diags = vmap(_single_m_step)(
+                emission_stats['Sx'], emission_stats['Sxsq'], emission_stats['N'])
+            params = params._replace(weights=weights, means=means, scale_diags=scale_diags)
         return params, m_step_state
 
 

--- a/dynamax/hidden_markov_model/models/linreg_hmm.py
+++ b/dynamax/hidden_markov_model/models/linreg_hmm.py
@@ -12,7 +12,7 @@ from dynamax.hidden_markov_model.inference import HMMPosterior
 from dynamax.hidden_markov_model.models.abstractions import HMM, HMMEmissions, HMMParameterSet, HMMPropertySet
 from dynamax.hidden_markov_model.models.initial import StandardHMMInitialState, ParamsStandardHMMInitialState
 from dynamax.hidden_markov_model.models.transitions import StandardHMMTransitions, ParamsStandardHMMTransitions
-from dynamax.parameters import ParameterProperties
+from dynamax.parameters import ParameterProperties, ensure_all_or_none_trainable
 from dynamax.types import Scalar
 from dynamax.utils.utils import pytree_sum
 from dynamax.utils.bijectors import RealToPSDBijector
@@ -157,32 +157,32 @@ class LinearRegressionHMMEmissions(HMMEmissions):
             m_step_state: Any
     ) -> Tuple[ParamsLinearRegressionHMMEmissions, Any]:
         """Perform the M-step of the EM algorithm."""
-        
-        def _single_m_step(stats):
-            """Perform the M-step for a single state."""
-            sum_w = stats['sum_w']
-            sum_x = stats['sum_x']
-            sum_y = stats['sum_y']
-            sum_xxT = stats['sum_xxT']
-            sum_xyT = stats['sum_xyT']
-            sum_yyT = stats['sum_yyT']
+        if ensure_all_or_none_trainable(props):
+            def _single_m_step(stats):
+                """Perform the M-step for a single state."""
+                sum_w = stats['sum_w']
+                sum_x = stats['sum_x']
+                sum_y = stats['sum_y']
+                sum_xxT = stats['sum_xxT']
+                sum_xyT = stats['sum_xyT']
+                sum_yyT = stats['sum_yyT']
 
-            # Make block matrices for stacking features (x) and bias (1)
-            sum_x1x1T = jnp.block(
-                [[sum_xxT,                   jnp.expand_dims(sum_x, 1)],
-                 [jnp.expand_dims(sum_x, 0), jnp.expand_dims(sum_w, (0, 1))]]
-            )
-            sum_x1yT = jnp.vstack([sum_xyT, sum_y])
+                # Make block matrices for stacking features (x) and bias (1)
+                sum_x1x1T = jnp.block(
+                    [[sum_xxT,                   jnp.expand_dims(sum_x, 1)],
+                     [jnp.expand_dims(sum_x, 0), jnp.expand_dims(sum_w, (0, 1))]]
+                )
+                sum_x1yT = jnp.vstack([sum_xyT, sum_y])
 
-            # Solve for the optimal A, b, and Sigma
-            Ab = jnp.linalg.solve(sum_x1x1T, sum_x1yT).T
-            Sigma = 1 / sum_w * (sum_yyT - Ab @ sum_x1yT)
-            Sigma = 0.5 * (Sigma + Sigma.T)                 # for numerical stability
-            return Ab[:, :-1], Ab[:, -1], Sigma
+                # Solve for the optimal A, b, and Sigma
+                Ab = jnp.linalg.solve(sum_x1x1T, sum_x1yT).T
+                Sigma = 1 / sum_w * (sum_yyT - Ab @ sum_x1yT)
+                Sigma = 0.5 * (Sigma + Sigma.T)                 # for numerical stability
+                return Ab[:, :-1], Ab[:, -1], Sigma
 
-        emission_stats = pytree_sum(batch_stats, axis=0)
-        As, bs, Sigmas = vmap(_single_m_step)(emission_stats)
-        params = params._replace(weights=As, biases=bs, covs=Sigmas)
+            emission_stats = pytree_sum(batch_stats, axis=0)
+            As, bs, Sigmas = vmap(_single_m_step)(emission_stats)
+            params = params._replace(weights=As, biases=bs, covs=Sigmas)
         return params, m_step_state
 
 

--- a/dynamax/hidden_markov_model/models/test_models.py
+++ b/dynamax/hidden_markov_model/models/test_models.py
@@ -6,6 +6,7 @@ import jax.random as jr
 import pytest
 
 from jax import vmap
+from jax.tree_util import tree_leaves, tree_map
 from dynamax.utils.utils import monotonically_increasing
 
 NUM_TIMESTEPS = 50
@@ -39,6 +40,80 @@ def test_sample_and_fit(cls, kwargs, inputs):
     fitted_params, lps = hmm.fit_em(params, param_props, emissions, inputs=inputs, num_iters=10)
     assert monotonically_increasing(lps, atol=1e-2, rtol=1e-2)
     fitted_params, lps = hmm.fit_sgd(params, param_props, emissions, inputs=inputs, num_epochs=10)
+
+
+# Models whose closed-form emission m_step updates its parameters jointly, so they
+# currently support freezing all of the emission parameters or none, but nothing in between.
+JOINT_M_STEP_CONFIGS = [
+    (models.GaussianHMM, dict(num_states=3, emission_dim=2)),
+    (models.DiagonalGaussianHMM, dict(num_states=3, emission_dim=2)),
+    (models.SharedCovarianceGaussianHMM, dict(num_states=3, emission_dim=2)),
+    (models.LinearRegressionHMM, dict(num_states=3, emission_dim=2, input_dim=2)),
+    (models.LinearAutoregressiveHMM, dict(num_states=3, emission_dim=2, num_lags=1)),
+    (models.GaussianMixtureHMM, dict(num_states=3, num_components=2, emission_dim=2)),
+    (models.DiagonalGaussianMixtureHMM, dict(num_states=3, num_components=2, emission_dim=2)),
+]
+
+
+@pytest.mark.parametrize(["cls", "kwargs"], JOINT_M_STEP_CONFIGS)
+def test_em_partially_frozen_emissions_raises(cls, kwargs):
+    """Test that freezing some but not all emission parameters makes m_step raise."""
+    hmm = cls(**kwargs)
+    params, props = hmm.initialize(jr.PRNGKey(0))
+    props.emissions[0].trainable = False  # freeze one emission parameter
+    # batch_stats=None makes the test fail if m_step uses the statistics before the guard
+    with pytest.raises(NotImplementedError):
+        hmm.emission_component.m_step(params.emissions, props.emissions, None, None)
+
+
+@pytest.mark.parametrize(["cls", "kwargs"], JOINT_M_STEP_CONFIGS)
+def test_em_all_frozen_emissions_unchanged(cls, kwargs):
+    """Test that freezing all emission parameters makes m_step return them unchanged."""
+    hmm = cls(**kwargs)
+    params, props = hmm.initialize(jr.PRNGKey(0))
+    for prop in props.emissions:
+        prop.trainable = False
+    new_params, _ = hmm.emission_component.m_step(params.emissions, props.emissions, None, None)
+    assert all(tree_leaves(tree_map(jnp.array_equal, new_params, params.emissions)))
+
+
+def test_em_respects_frozen_emissions():
+    """Test fit_em end-to-end with frozen emission parameters."""
+    hmm = models.GaussianHMM(num_states=3, emission_dim=2)
+    key1, key2 = jr.split(jr.PRNGKey(0))
+    true_params, _ = hmm.initialize(key1)
+    _, emissions = hmm.sample(true_params, key2, num_timesteps=NUM_TIMESTEPS)
+
+    # Fit from parameters different from those that generated the data, so the
+    # transition fitting update below is large.
+    params, props = hmm.initialize(jr.PRNGKey(1))
+
+    props.emissions.means.trainable = False
+    with pytest.raises(NotImplementedError):
+        hmm.fit_em(params, props, emissions, num_iters=3)
+
+    props.emissions.covs.trainable = False
+    fitted_params, lps = hmm.fit_em(params, props, emissions, num_iters=3)
+    assert jnp.array_equal(fitted_params.emissions.means, params.emissions.means)
+    assert jnp.array_equal(fitted_params.emissions.covs, params.emissions.covs)
+    assert not jnp.allclose(fitted_params.transitions.transition_matrix,
+                            params.transitions.transition_matrix)
+    assert monotonically_increasing(lps, atol=1e-2, rtol=1e-2)
+
+
+def test_sgd_supports_partially_frozen_emissions():
+    """Test that fit_sgd supports the partial freeze that fit_em refuses, as fit_em's error message advises."""
+    hmm = models.GaussianHMM(num_states=3, emission_dim=2)
+    key1, key2 = jr.split(jr.PRNGKey(0))
+    true_params, _ = hmm.initialize(key1)
+    _, emissions = hmm.sample(true_params, key2, num_timesteps=NUM_TIMESTEPS)
+
+    params, props = hmm.initialize(jr.PRNGKey(1))
+    props.emissions.means.trainable = False
+    fitted_params, _ = hmm.fit_sgd(params, props, emissions, num_epochs=5)
+
+    assert jnp.array_equal(fitted_params.emissions.means, params.emissions.means)
+    assert not jnp.allclose(fitted_params.emissions.covs, params.emissions.covs)
 
 
 ## A few model-specific tests

--- a/dynamax/linear_gaussian_ssm/models.py
+++ b/dynamax/linear_gaussian_ssm/models.py
@@ -18,7 +18,7 @@ from dynamax.ssm import SSM
 from dynamax.linear_gaussian_ssm.inference import lgssm_joint_sample, lgssm_filter, lgssm_smoother, lgssm_posterior_sample
 from dynamax.linear_gaussian_ssm.inference import ParamsLGSSM, ParamsLGSSMInitial, ParamsLGSSMDynamics, ParamsLGSSMEmissions
 from dynamax.linear_gaussian_ssm.inference import PosteriorGSSMFiltered, PosteriorGSSMSmoothed
-from dynamax.parameters import ParameterProperties
+from dynamax.parameters import ParameterProperties, ensure_all_or_none_trainable
 from dynamax.types import PRNGKeyT, Scalar
 from dynamax.utils.bijectors import RealToPSDBijector
 from dynamax.utils.distributions import MatrixNormalInverseWishart as MNIW
@@ -459,51 +459,48 @@ class LinearGaussianSSM(SSM):
                -> Tuple[ParamsLGSSM, Any]:
         """Perform the M-step of the EM algorithm.
 
-        Note: This function currently ignores any `trainable` constraints specified
-        in the `props` argument.
-        
         Args:
             params: model parameters.
             props: parameter properties.
             batch_stats: expected sufficient statistics.
             m_step_state: state for the M-step.
-        
+
         Returns:
             updated model parameters and updated M-step state.
         """
+        if ensure_all_or_none_trainable(props, what="parameters"):
+            def fit_linear_regression(ExxT, ExyT, EyyT, N):
+                """
+                Solve a linear regression given sufficient statistics
+                """
+                W = psd_solve(ExxT, ExyT).T
+                Sigma = (EyyT - W @ ExyT - ExyT.T @ W.T + W @ ExxT @ W.T) / N
+                return W, Sigma
 
-        def fit_linear_regression(ExxT, ExyT, EyyT, N):
-            """
-            Solve a linear regression given sufficient statistics
-            """
-            W = psd_solve(ExxT, ExyT).T
-            Sigma = (EyyT - W @ ExyT - ExyT.T @ W.T + W @ ExxT @ W.T) / N
-            return W, Sigma
+            # Sum the statistics across all batches
+            stats = tree_map(partial(jnp.sum, axis=0), batch_stats)
+            init_stats, dynamics_stats, emission_stats = stats
 
-        # Sum the statistics across all batches
-        stats = tree_map(partial(jnp.sum, axis=0), batch_stats)
-        init_stats, dynamics_stats, emission_stats = stats
+            # Perform MLE estimation jointly
+            sum_x0, sum_x0x0T, N = init_stats
+            S = (sum_x0x0T - jnp.outer(sum_x0, sum_x0)) / N
+            m = sum_x0 / N
 
-        # Perform MLE estimation jointly
-        sum_x0, sum_x0x0T, N = init_stats
-        S = (sum_x0x0T - jnp.outer(sum_x0, sum_x0)) / N
-        m = sum_x0 / N
+            FB, Q = fit_linear_regression(*dynamics_stats)
+            F = FB[:, :self.state_dim]
+            B, b = (FB[:, self.state_dim:-1], FB[:, -1]) if self.has_dynamics_bias \
+                else (FB[:, self.state_dim:], None)
 
-        FB, Q = fit_linear_regression(*dynamics_stats)
-        F = FB[:, :self.state_dim]
-        B, b = (FB[:, self.state_dim:-1], FB[:, -1]) if self.has_dynamics_bias \
-            else (FB[:, self.state_dim:], None)
+            HD, R = fit_linear_regression(*emission_stats)
+            H = HD[:, :self.state_dim]
+            D, d = (HD[:, self.state_dim:-1], HD[:, -1]) if self.has_emissions_bias \
+                else (HD[:, self.state_dim:], None)
 
-        HD, R = fit_linear_regression(*emission_stats)
-        H = HD[:, :self.state_dim]
-        D, d = (HD[:, self.state_dim:-1], HD[:, -1]) if self.has_emissions_bias \
-            else (HD[:, self.state_dim:], None)
-
-        params = ParamsLGSSM(
-            initial=ParamsLGSSMInitial(mean=m, cov=S),
-            dynamics=ParamsLGSSMDynamics(weights=F, bias=b, input_weights=B, cov=Q),
-            emissions=ParamsLGSSMEmissions(weights=H, bias=d, input_weights=D, cov=R)
-        )
+            params = ParamsLGSSM(
+                initial=ParamsLGSSMInitial(mean=m, cov=S),
+                dynamics=ParamsLGSSMDynamics(weights=F, bias=b, input_weights=B, cov=Q),
+                emissions=ParamsLGSSMEmissions(weights=H, bias=d, input_weights=D, cov=R)
+            )
         return params, m_step_state
 
 
@@ -603,9 +600,6 @@ class LinearGaussianConjugateSSM(LinearGaussianSSM):
                batch_stats: SuffStatsLGSSM,
                m_step_state: Any):
         """Perform the M-step of the EM algorithm.
-        
-        Note: This function currently ignores any `trainable` constraints specified
-        in the `props` argument.
 
         Args:
             params: model parameters.
@@ -616,31 +610,32 @@ class LinearGaussianConjugateSSM(LinearGaussianSSM):
         Returns:
             updated model parameters and updated M-step state.
         """
-        # Sum the statistics across all batches
-        stats = tree_map(partial(jnp.sum, axis=0), batch_stats)
-        init_stats, dynamics_stats, emission_stats = stats
+        if ensure_all_or_none_trainable(props, what="parameters"):
+            # Sum the statistics across all batches
+            stats = tree_map(partial(jnp.sum, axis=0), batch_stats)
+            init_stats, dynamics_stats, emission_stats = stats
 
-        # Perform MAP estimation jointly
-        initial_posterior = niw_posterior_update(self.initial_prior, init_stats)
-        S, m = initial_posterior.mode()
+            # Perform MAP estimation jointly
+            initial_posterior = niw_posterior_update(self.initial_prior, init_stats)
+            S, m = initial_posterior.mode()
 
-        dynamics_posterior = mniw_posterior_update(self.dynamics_prior, dynamics_stats)
-        Q, FB = dynamics_posterior.mode()
-        F = FB[:, :self.state_dim]
-        B, b = (FB[:, self.state_dim:-1], FB[:, -1]) if self.has_dynamics_bias \
-            else (FB[:, self.state_dim:], jnp.zeros(self.state_dim))
+            dynamics_posterior = mniw_posterior_update(self.dynamics_prior, dynamics_stats)
+            Q, FB = dynamics_posterior.mode()
+            F = FB[:, :self.state_dim]
+            B, b = (FB[:, self.state_dim:-1], FB[:, -1]) if self.has_dynamics_bias \
+                else (FB[:, self.state_dim:], jnp.zeros(self.state_dim))
 
-        emission_posterior = mniw_posterior_update(self.emission_prior, emission_stats)
-        R, HD = emission_posterior.mode()
-        H = HD[:, :self.state_dim]
-        D, d = (HD[:, self.state_dim:-1], HD[:, -1]) if self.has_emissions_bias \
-            else (HD[:, self.state_dim:], jnp.zeros(self.emission_dim))
+            emission_posterior = mniw_posterior_update(self.emission_prior, emission_stats)
+            R, HD = emission_posterior.mode()
+            H = HD[:, :self.state_dim]
+            D, d = (HD[:, self.state_dim:-1], HD[:, -1]) if self.has_emissions_bias \
+                else (HD[:, self.state_dim:], jnp.zeros(self.emission_dim))
 
-        params = ParamsLGSSM(
-            initial=ParamsLGSSMInitial(mean=m, cov=S),
-            dynamics=ParamsLGSSMDynamics(weights=F, bias=b, input_weights=B, cov=Q),
-            emissions=ParamsLGSSMEmissions(weights=H, bias=d, input_weights=D, cov=R)
-        )
+            params = ParamsLGSSM(
+                initial=ParamsLGSSMInitial(mean=m, cov=S),
+                dynamics=ParamsLGSSMDynamics(weights=F, bias=b, input_weights=B, cov=Q),
+                emissions=ParamsLGSSMEmissions(weights=H, bias=d, input_weights=D, cov=R)
+            )
         return params, m_step_state
 
     def fit_blocked_gibbs(self,

--- a/dynamax/linear_gaussian_ssm/models_test.py
+++ b/dynamax/linear_gaussian_ssm/models_test.py
@@ -6,6 +6,7 @@ from itertools import count
 
 import pytest
 from jax import vmap
+from jax.tree_util import tree_leaves, tree_map
 import jax.numpy as jnp
 import jax.random as jr
 
@@ -20,6 +21,7 @@ CONFIGS = [
     (LinearGaussianConjugateSSM, dict(state_dim=2, emission_dim=10), None),
 ]
 
+
 @pytest.mark.parametrize(["cls", "kwargs", "inputs"], CONFIGS)
 def test_sample_and_fit(cls, kwargs, inputs):
     """
@@ -33,6 +35,55 @@ def test_sample_and_fit(cls, kwargs, inputs):
     fitted_params, lps = model.fit_em(params, param_props, emissions, inputs=inputs, num_iters=3)
     assert monotonically_increasing(lps)
     fitted_params, lps = model.fit_sgd(params, param_props, emissions, inputs=inputs, num_epochs=3)
+
+
+@pytest.mark.parametrize("cls", [LinearGaussianSSM, LinearGaussianConjugateSSM])
+def test_em_partially_frozen_params_raises(cls):
+    """
+    Test that freezing some but not all parameters makes m_step raise.
+    """
+    model = cls(state_dim=2, emission_dim=3)
+    params, props = model.initialize(jr.PRNGKey(0))
+
+    props.dynamics.weights.trainable = False
+    # batch_stats=None makes the test fail if m_step uses the statistics before the guard
+    with pytest.raises(NotImplementedError):
+        model.m_step(params, props, None, None)
+
+
+@pytest.mark.parametrize("cls", [LinearGaussianSSM, LinearGaussianConjugateSSM])
+def test_em_all_frozen_params_unchanged(cls):
+    """
+    Test that freezing all parameters makes m_step return them unchanged.
+    """
+    model = cls(state_dim=2, emission_dim=3)
+    params, props = model.initialize(jr.PRNGKey(0))
+    for group in props:
+        for prop in group:
+            prop.trainable = False
+    new_params, _ = model.m_step(params, props, None, None)
+    assert all(tree_leaves(tree_map(jnp.array_equal, new_params, params)))
+
+
+def test_sgd_supports_frozen_params():
+    """
+    Test that fit_sgd supports the partial freeze that fit_em refuses, as fit_em's error message advises.
+    """
+    model = LinearGaussianSSM(state_dim=2, emission_dim=3)
+    key1, key2 = jr.split(jr.PRNGKey(0))
+    # Generate data with a different dynamics covariance than the starting
+    # params (initialize() defaults it to 0.1*I for every key), so the fitting
+    # update below is large.
+    true_params, _ = model.initialize(key1, dynamics_covariance=0.5 * jnp.eye(2))
+    _, emissions = model.sample(true_params, key2, num_timesteps=NUM_TIMESTEPS)
+
+    params, props = model.initialize(jr.PRNGKey(1))
+    props.dynamics.weights.trainable = False
+    fitted_params, _ = model.fit_sgd(params, props, emissions, num_epochs=5)
+
+    assert jnp.array_equal(fitted_params.dynamics.weights, params.dynamics.weights)
+    assert not jnp.allclose(fitted_params.dynamics.cov, params.dynamics.cov)
+
 
 def test_fit_blocked_gibbs_batched():
     """

--- a/dynamax/parameters.py
+++ b/dynamax/parameters.py
@@ -3,9 +3,9 @@ Helpers for managing parameters and their properties as PyTrees.
 """
 import jax.numpy as jnp
 from jax import lax
-from jax.tree_util import tree_reduce, tree_map, register_pytree_node_class
+from jax.tree_util import tree_reduce, tree_map, tree_leaves, register_pytree_node_class
 import tensorflow_probability.substrates.jax.bijectors as tfb
-from typing import Optional, runtime_checkable
+from typing import List, Optional, runtime_checkable
 from typing_extensions import Protocol
 
 from dynamax.types import Scalar
@@ -55,6 +55,37 @@ class ParameterProperties:
     def __repr__(self):
         """Return a string representation of the PyTree."""
         return f"ParameterProperties(trainable={self.trainable}, constrainer={self.constrainer})"
+
+
+def trainable_flags(props: PropertySet) -> List[bool]:
+    """List the ``trainable`` flag of every :class:`ParameterProperties` in ``props``.
+
+    Args:
+        props: (nested) named tuple whose leaf values are ParameterProperties.
+
+    Returns:
+        flags: list of boolean ``trainable`` flags, one per property.
+    """
+    is_leaf = lambda node: isinstance(node, (ParameterProperties,))
+    return [prop.trainable for prop in tree_leaves(props, is_leaf=is_leaf)]
+
+
+def ensure_all_or_none_trainable(props: PropertySet, what: str = "emission parameters") -> bool:
+    """Raise if some but not all of the properties in ``props`` are frozen.
+
+    Args:
+        props: (nested) named tuple whose leaf values are ParameterProperties.
+        what: name for the parameters in ``props``.
+
+    Returns:
+        all_trainable: True if all properties are trainable, False if all are frozen.
+    """
+    flags = trainable_flags(props)
+    if any(flags) and not all(flags):
+        raise NotImplementedError(
+            f"This model's fit_em() does not support fitting some but not all of the "
+            f"{what}; set them all trainable or all frozen, or use fit_sgd().")
+    return all(flags)
 
 
 def to_unconstrained(params: ParameterSet, props: PropertySet) -> ParameterSet:

--- a/dynamax/parameters_test.py
+++ b/dynamax/parameters_test.py
@@ -2,9 +2,11 @@
 import copy
 import jax.numpy as jnp
 import optax
+import pytest
 import tensorflow_probability.substrates.jax.bijectors as tfb
 
 from dynamax.parameters import ParameterProperties, to_unconstrained, from_unconstrained, log_det_jac_constrain
+from dynamax.parameters import trainable_flags, ensure_all_or_none_trainable
 from jax import jit, value_and_grad, lax
 from jax.tree_util import tree_map, tree_leaves
 from jaxtyping import Float, Array
@@ -45,6 +47,21 @@ def make_params():
         emissions=EmissionsParams(means=ParameterProperties(), scales=ParameterProperties(constrainer=tfb.Softplus(), trainable=False))
     )
     return params, props
+
+
+def test_trainable_flags_helpers():
+    """Test trainable_flags and ensure_all_or_none_trainable on nested props."""
+    _, props = make_params()
+
+    # The flags of every ParameterProperties in the (nested) PyTree, in order.
+    # tree_leaves must stop at ParameterProperties, which flatten to zero children.
+    assert trainable_flags(props) == [False, True, True, False]
+
+    # All trainable -> True, all frozen -> False, mixed -> NotImplementedError
+    assert ensure_all_or_none_trainable(props.transitions)
+    assert not ensure_all_or_none_trainable(props.initial)
+    with pytest.raises(NotImplementedError):
+        ensure_all_or_none_trainable(props.emissions)
 
 
 def test_parameter_tofrom_unconstrained():


### PR DESCRIPTION
# Summary
- Fixes #350
- Fitting some models with EM silently ignores `trainable=False`. Further, the models that do respect the flag disagree on the policy: for example, the GMM HMMs reject freezing all emission parameters while `GaussianHMM` allows it.
- This PR fixes the bug and implements a consistent policy on parameter freezing across Dynamax
# Details
- The policy I’m suggesting:
    - When using EM with a closed-form M-step: HMMs can freeze all or no emission parameters (and independently freeze the initial and transition parameters in any combination — no change to this behavior), and LGSSMs can freeze all or no parameters
    - Unsupported freezes raise, with instruction to use `fit_sgd`, which supports any combination of frozen parameters
- Future PRs could relax this policy
    - HMMs: Could support updates for specific combinations of frozen emission parameters (new math needed)
    - LGSSM: Could support updates for blocks of parameters (no new math needed)
- There should be no performance impact from this change
    - The new guards run entirely at trace time (`trainable` is static), so EM's XLA programs are identical before and after this PR when all parameters are trainable (verified by comparing `jaxpr` for all 9 affected models)
- I have tried to keep functional changes to a minimum (this PR is 58% whitespace / indentation and 28% tests)